### PR TITLE
Make Observer->_getCampaignCookie simpler

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -250,18 +250,13 @@ class Ebizmarts_MailChimp_Model_Observer
     }
 
     /**
-     * Get campaign cooke if available.
+     * Get campaign cookie if available.
      *
-     * @return null
+     * @return mixed
      */
     protected function _getCampaignCookie()
     {
-        $cookie = Mage::getModel('core/cookie')->get('mailchimp_campaign_id');
-        if ($cookie && Mage::getModel('core/cookie')->getLifetime('mailchimp_campaign_id') == Mage::getStoreConfig(Mage_Core_Model_Cookie::XML_PATH_COOKIE_LIFETIME, Mage::app()->getStore()->getId())) {
-            return $cookie;
-        } else {
-            return null;
-        }
+        return Mage::getModel('core/cookie')->get('mailchimp_campaign_id');
     }
 
     /**


### PR DESCRIPTION
`Mage::getModel('core/cookie')->getLifetime('mailchimp_campaign_id')`
This function doesn't take an argument, and will return `Mage::getStoreConfig(self::XML_PATH_COOKIE_LIFETIME, $this->getStore())`
This means the comparison will always return true and can be removed

If the cookie isn't set it `Zend_Controller_Request_Abstract` will
return null, the return value looks like it's being used as a bool
everywhere, so there seems little point testing to return null.
Alternatively I guess it could return the literal false if it evaluates
to it.