### PR TITLE
Stop calling getLifetime

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -260,7 +260,7 @@ class Ebizmarts_MailChimp_Model_Observer
             Mage::getModel('core/cookie')->delete('mailchimp_campaign_id');
         }
 
-        if(($this->_getLandingCookie())) {
+        if ($this->_getLandingCookie()) {
             Mage::getModel('core/cookie')->delete('mailchimp_landing_page');
         }
 
@@ -268,32 +268,28 @@ class Ebizmarts_MailChimp_Model_Observer
     }
 
     /**
-     * Get campaign cooke if available.
+     * Get campaign cookie if available.
      *
-     * @return null
+     * @return mixed
      */
     protected function _getCampaignCookie()
     {
         $landingCookie = $this->_getLandingCookie();
         if (preg_match("/utm_source=mailchimp/", $landingCookie)) {
-            return null;
+            return false;
         }
 
-        $cookie = Mage::getModel('core/cookie')->get('mailchimp_campaign_id');
-        if ($cookie && Mage::getModel('core/cookie')->getLifetime('mailchimp_campaign_id') == Mage::getStoreConfig(Mage_Core_Model_Cookie::XML_PATH_COOKIE_LIFETIME, Mage::app()->getStore()->getId())) {
-            return $cookie;
-        } else {
-            return null;
-        }
+        return Mage::getModel('core/cookie')->get('mailchimp_campaign_id');
     }
+
+    /**
+     * Get landing cookie if available.
+     *
+     * @return mixed
+     */
     protected function _getLandingCookie()
     {
-        $cookie = Mage::getModel('core/cookie')->get('mailchimp_landing_page');
-        if ($cookie && Mage::getModel('core/cookie')->getLifetime('mailchimp_landing_page') == Mage::getStoreConfig(Mage_Core_Model_Cookie::XML_PATH_COOKIE_LIFETIME, Mage::app()->getStore()->getId())) {
-            return $cookie;
-        } else {
-            return null;
-        }
+        return Mage::getModel('core/cookie')->get('mailchimp_landing_page');
     }
 
     /**


### PR DESCRIPTION
Mage::getModel('core/cookie')->getLifetime doesn't have any parameters,
and returns
Mage::getStoreConfig(Mage_Core_Model_Cookie::XML_PATH_COOKIE_LIFETIME,
Mage::app()->getStore()->getId()) so the comparisons in
_getCampaignCookie and _getLandingCookie always return true. Both
functions are tested for truthiness when they're used, and
Mage::getModel('core/cookie')->get returns false when the cookie isn't
set, so both function should be able to return the ->get call