### PR TITLE
Remove m4mlogs.sh and getMailchimpResponse.php from document root

### DIFF
--- a/modman
+++ b/modman
@@ -11,5 +11,5 @@ lib/Ebizmarts/Mailchimp                                              lib/Ebizmar
 lib/Mandrill                                                         lib/Mandrill
 skin/adminhtml/default/default/ebizmarts/mailchimp                   skin/adminhtml/default/default/ebizmarts/mailchimp
 skin/adminhtml/default/default/ebizmarts/mandrill                    skin/adminhtml/default/default/ebizmarts/mandrill
-m4mlogs.sh                                                           m4mlogs.sh
-getMailchimpResponse.php                                             getMailchimpResponse.php
+m4mlogs.sh                                                           shell/m4mlogs.sh
+getMailchimpResponse.php                                             shell/getMailchimpResponse.php


### PR DESCRIPTION
Current module version adds m4mlogs.sh and getMailchimpResponse.php to magento web root. Such behavior could be used by potential hackers to detect that mailchimp module installed and execute direct attack to this module.

These files could be used only for debugging, so they should not be available for everyone.