### PR TITLE
Fix unsubscribe & delete on Newsletter Subscribers grid

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -129,9 +129,16 @@ class Ebizmarts_MailChimp_Model_Observer
                 );
             }
 
-
             if (TRUE === $subscriber->getIsStatusChanged()) {
                 Mage::getModel('mailchimp/api_subscribers')->updateSubscriber($subscriber, true);
+            } else {
+                $origData = $subscriber->getOrigData();
+
+                if (is_array($origData) && isset($origData['subscriber_status']) &&
+                    $origData['subscriber_status'] != $subscriber->getSubscriberStatus()
+                ) {
+                    Mage::getModel('mailchimp/api_subscribers')->updateSubscriber($subscriber, true);
+                }
             }
         }
     }
@@ -146,9 +153,8 @@ class Ebizmarts_MailChimp_Model_Observer
         $isEnabled = Mage::helper('mailchimp')->getConfigValue(Ebizmarts_MailChimp_Model_Config::GENERAL_ACTIVE);
         if ($isEnabled) {
             $subscriber = $observer->getEvent()->getSubscriber();
-            if (TRUE === $subscriber->getIsStatusChanged()) {
-                Mage::getModel('mailchimp/api_subscribers')->deleteSubscriber($subscriber);
-            }
+
+            Mage::getModel('mailchimp/api_subscribers')->deleteSubscriber($subscriber);
         }
     }
 


### PR DESCRIPTION
We've found an issue in latest version of module.

Related forum thread:
https://ebizmarts.com/forums/topics/view/25076


**Steps to reproduce:**
1. Go to frontend and subscribe to newsletter
2. Go to Admin --> Newsletter --> Newsletter Subscribers
3. Select customer which was subscribed and in "Mass Action" list execute "unsubsribe" or "delete" action

**Expected result:**
Subscriber was unsubsribed (or deleted) in Magento and Mailchimp.

**Actual result:**
Subscriber was unsubsribed (or deleted) in Magento, but it wasn't unsubsribed from Mailchimp