### PR TITLE
Add support for profile updates

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/ProcessWebhook.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/ProcessWebhook.php
@@ -166,7 +166,10 @@ class Ebizmarts_MailChimp_Model_ProcessWebhook
         $email = $data['data']['email'];
         $subscriber = $this->loadByEmail($email);
 
-        $customer = Mage::getModel('customer/customer')->loadByEmail($email);
+        $customer = Mage::getModel('customer/customer')
+            ->setWebsiteId(Mage::app()->getStore()->getWebsiteId())
+            ->loadByEmail($email);
+
         if ($customer->getId()) {
             $toUpdate = $customer;
             $toUpdate->setFirstname($data['data']['merges']['FNAME']);

--- a/app/code/community/Ebizmarts/MailChimp/Model/ProcessWebhook.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/ProcessWebhook.php
@@ -40,6 +40,9 @@ class Ebizmarts_MailChimp_Model_ProcessWebhook
             case 'upemail':
                 $this->_updateEmail($data);
                 break;
+            case 'profile':
+                $this->_profile($data);
+                break;
         }
     }
 
@@ -167,12 +170,14 @@ class Ebizmarts_MailChimp_Model_ProcessWebhook
             ->addFieldToFilter('email', array('eq' => $email));
         if (count($customerCollection) > 0) {
             $toUpdate = $customerCollection->getFirstItem();
+            $toUpdate->setFirstname($data['data']['merges']['FNAME']);
+            $toUpdate->setLastname($data['data']['merges']['LNAME']);
         } else {
             $toUpdate = $subscriber;
+            $toUpdate->setSubscriberFirstname($data['data']['merges']['FNAME']);
+            $toUpdate->setSubscriberLastname($data['data']['merges']['LNAME']);
         }
 
-        $toUpdate->setFirstname($data['data']['merges']['FNAME']);
-        $toUpdate->setLastname($data['data']['merges']['LNAME']);
         $toUpdate->save();
 
 

--- a/app/code/community/Ebizmarts/MailChimp/Model/ProcessWebhook.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/ProcessWebhook.php
@@ -166,10 +166,9 @@ class Ebizmarts_MailChimp_Model_ProcessWebhook
         $email = $data['data']['email'];
         $subscriber = $this->loadByEmail($email);
 
-        $customerCollection = Mage::getModel('customer/customer')->getCollection()
-            ->addFieldToFilter('email', array('eq' => $email));
-        if (count($customerCollection) > 0) {
-            $toUpdate = $customerCollection->getFirstItem();
+        $customer = Mage::getModel('customer/customer')->loadByEmail($email);
+        if ($customer->getId()) {
+            $toUpdate = $customer;
             $toUpdate->setFirstname($data['data']['merges']['FNAME']);
             $toUpdate->setLastname($data['data']['merges']['LNAME']);
         } else {


### PR DESCRIPTION
**Steps to reproduce:**
1. Configure Mailchimp module & webhook
2. Subscribe subscriber via Magento
3. Go to Mailchimp, find subscriber that was added in step 2
4. Update First name & click "save" button (on mailchimp)

**Actual result:**
On Magento we have old first name

**Expected result**
On Magento we have updated first name



Note: _profile method had issue when subscriber is not related to customer even after adding "profile" case to processWebhookData method