### PR TITLE
Fix  first & last name processing on subscribe webhook

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/ProcessWebhook.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/ProcessWebhook.php
@@ -105,13 +105,13 @@ class Ebizmarts_MailChimp_Model_ProcessWebhook
                     ->save();
             } else {
                 $subscriber = Mage::getModel('newsletter/subscriber')->setImportMode(TRUE);
-                if (isset($data['data']['fname'])) {
-                    $subscriberFname = filter_var($data['data']['fname'], FILTER_SANITIZE_STRING);
+                if (isset($data['data']['merges']['FNAME'])) {
+                    $subscriberFname = filter_var($data['data']['merges']['FNAME'], FILTER_SANITIZE_STRING);
                     $subscriber->setSubscriberFirstname($subscriberFname);
                 }
 
-                if (isset($data['data']['lname'])) {
-                    $subscriberLname = filter_var($data['data']['lname'], FILTER_SANITIZE_STRING);
+                if (isset($data['data']['merges']['LNAME'])) {
+                    $subscriberLname = filter_var($data['data']['merges']['LNAME'], FILTER_SANITIZE_STRING);
                     $subscriber->setSubscriberLastname($subscriberLname);
                 }
 


### PR DESCRIPTION
**Steps to reproduce:**
1. Go to Mailchimp, select list that you're using for sync with Magento
2. Navigate to "Add contacts -->  Add a subscriber"
3. Fill email, first & last name
4. Click to "Subscribe" button

**Actual result:**
In Magento we have subscriber, but first & last name are missing

**Expected result:**
In Magento we should have first & last name retrieved from Mailchimp.