### PR TITLE
Hotfix/pr 174 fix email queue sending

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Helper/Mandrill.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Mandrill.php
@@ -36,4 +36,25 @@ class Ebizmarts_MailChimp_Helper_Mandrill extends Mage_Core_Helper_Abstract
         $version = strpos(Mage::getVersion(), '-') ? substr(Mage::getVersion(), 0, strpos(Mage::getVersion(), '-')) : Mage::getVersion();
         return (string)'Ebizmarts_Mandrill' . $v . '/Mage' . $aux . $version;
     }
+
+    /**
+     * Returns a boolean value to represent if Mandrill is enabled or not.
+     *
+     * @param  null|string|integer  $storeId
+     * @return boolean
+     */
+    public function isEnabled($storeId = null)
+    {
+        return (bool) Mage::getStoreConfigFlag(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE, $storeId);
+    }
+
+    /**
+     * Returns the Mandrill API Key
+     * @param  null|string|integer$storeId [description]
+     * @return [type]          [description]
+     */
+    public function getMandrillApiKey($storeId = null)
+    {
+        return Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_APIKEY, $storeId);
+    }
 }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Email/Queue.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Email/Queue.php
@@ -19,129 +19,94 @@ class Ebizmarts_MailChimp_Model_Email_Queue extends Mage_Core_Model_Email_Queue
      */
     public function send()
     {
+        $storeId = Mage::app()->getStore()->getId();
+
         /** @var $collection Mage_Core_Model_Resource_Email_Queue_Collection */
         $collection = Mage::getModel('core/email_queue')->getCollection()
             ->addOnlyForSendingFilter()
             ->setPageSize(self::MESSAGES_LIMIT_PER_CRON_RUN)
             ->setCurPage(1)
             ->load();
+
         /** @var $message Mage_Core_Model_Email_Queue */
         foreach ($collection as $message) {
             if ($message->getId()) {
-                if ($message->getEntityType() == 'order') {
-                    $order = Mage::getModel('sales/order')->load($message->getEntityId());
-                    $storeId = $order->getStoreId();
-                    if (Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE, $storeId)) {
-                        $parameters = new Varien_Object($message->getMessageParameters());
-                        $mailer = $this->getMail($storeId);
-                        $mailer->setFrom($parameters->getFromEmail(), $parameters->getFromName());
-                        $mailer->setSubject($parameters->getSubject());
-                        if ($parameters->getIsPlain()) {
-                            $mailer->setBodyText($message->getMessageBody());
-                        } else {
-                            $mailer->setBodyHtml($message->getMessageBody());
-                        }
+                $parameters = new Varien_Object($message->getMessageParameters());
+                $mandrillEnabled = Mage::helper('mailchimp/mandrill')->isEnabled($storeId);
 
-                        try {
-                            foreach ($message->getRecipients() as $recipient) {
-                                list($email, $name, $type) = $recipient;
-                                switch ($type) {
-                                    case self::EMAIL_TYPE_TO:
-                                    case self::EMAIL_TYPE_CC:
-                                        $mailer->addTo($email, $name);
-                                        break;
-                                    case self::EMAIL_TYPE_BCC:
-                                        $mailer->addBcc($email);
-                                        break;
-                                }
-                            }
-
-                            if ($parameters->getReplyTo() !== null) {
-                                $mailer->setReplyTo($parameters->getReplyTo());
-                            }
-
-                            if ($parameters->getReturnTo() !== null) {
-                                $mailer->setReturnPath($parameters->getReturnTo());
-                            }
-
-                            try {
-                                Mage::dispatchEvent(
-                                    'fooman_emailattachments_before_send_queue',
-                                    array(
-                                        'mailer' => $mailer,
-                                        'message' => $message,
-                                        'mail_transport' => false
-
-                                    )
-                                );
-                                $mailer->send();
-                            } catch (Exception $e) {
-                                Mage::logException($e);
-                            }
-
-                            unset($mailer);
-                            $message->setProcessedAt(Varien_Date::formatDate(true));
-                            $message->save();
-                        } catch (Exception $e) {
-                            Mage::logException($e);
-                        }
-                    }else{
-                        $parameters = new Varien_Object($message->getMessageParameters());
-                        if ($parameters->getReturnPathEmail() !== null) {
-                            $mailTransport = new Zend_Mail_Transport_Sendmail("-f" . $parameters->getReturnPathEmail());
-                            Zend_Mail::setDefaultTransport($mailTransport);
-                        }
-
-                        $mailer = new Zend_Mail('utf-8');
-                        foreach ($message->getRecipients() as $recipient) {
-                            list($email, $name, $type) = $recipient;
-                            switch ($type) {
-                                case self::EMAIL_TYPE_BCC:
-                                    $mailer->addBcc($email, '=?utf-8?B?' . base64_encode($name) . '?=');
-                                    break;
-                                case self::EMAIL_TYPE_TO:
-                                case self::EMAIL_TYPE_CC:
-                                default:
-                                    $mailer->addTo($email, '=?utf-8?B?' . base64_encode($name) . '?=');
-                                    break;
-                            }
-                        }
-
-                        if ($parameters->getIsPlain()) {
-                            $mailer->setBodyText($message->getMessageBody());
-                        } else {
-                            $mailer->setBodyHTML($message->getMessageBody());
-                        }
-
-                        $mailer->setSubject('=?utf-8?B?' . base64_encode($parameters->getSubject()) . '?=');
-                        $mailer->setFrom($parameters->getFromEmail(), $parameters->getFromName());
-                        if ($parameters->getReplyTo() !== null) {
-                            $mailer->setReplyTo($parameters->getReplyTo());
-                        }
-
-                        if ($parameters->getReturnTo() !== null) {
-                            $mailer->setReturnPath($parameters->getReturnTo());
-                        }
-
-                        try {
-                            Mage::dispatchEvent(
-                                'fooman_emailattachments_before_send_queue',
-                                array(
-                                    'mailer'         => $mailer,
-                                    'message'        => $message,
-                                    'mail_transport' => false
-
-                                )
-                            );
-                            $mailer->send();
-                        } catch (Exception $e) {
-                            Mage::logException($e);
-                        }
-
-                        unset($mailer);
-                        $message->setProcessedAt(Varien_Date::formatDate(true));
-                        $message->save();
+                if ($mandrillEnabled) {
+                    // send email via Mandrill
+                    $mailer = $this->getMail($storeId);
+                } else {
+                    // send email via a Zend_Mail transport
+                    if ($parameters->getReturnPathEmail() !== null) {
+                        $mailTransport = new Zend_Mail_Transport_Sendmail("-f" . $parameters->getReturnPathEmail());
+                        Zend_Mail::setDefaultTransport($mailTransport);
                     }
+
+                    $mailer = new Zend_Mail('utf-8');
+                }
+
+                /**
+                 * DRYer version of setting the mailer values and sending it.
+                 * No need repeating it for Mandrill and Zend_Mail
+                 */
+
+                $mailer->setFrom($parameters->getFromEmail(), $parameters->getFromName());
+                if ($mandrillEnabled) {
+                    $mailer->setSubject($parameters->getSubject());
+                } else {
+                    // Zend_Mail version of subject
+                    $mailer->setSubject('=?utf-8?B?' . base64_encode($parameters->getSubject()) . '?=');
+                }
+
+                if ($parameters->getIsPlain()) {
+                    $mailer->setBodyText($message->getMessageBody());
+                } else {
+                    $mailer->setBodyHtml($message->getMessageBody());
+                }
+
+                try {
+                    foreach ($message->getRecipients() as $recipient) {
+                        list($email, $name, $type) = $recipient;
+                        switch ($type) {
+                            case self::EMAIL_TYPE_TO:
+                            case self::EMAIL_TYPE_CC:
+                                $mailer->addTo($email, $name);
+                                break;
+                            case self::EMAIL_TYPE_BCC:
+                                $mailer->addBcc($email);
+                                break;
+                        }
+                    }
+
+                    if ($parameters->getReplyTo() !== null) {
+                        $mailer->setReplyTo($parameters->getReplyTo());
+                    }
+
+                    if ($parameters->getReturnTo() !== null) {
+                        $mailer->setReturnPath($parameters->getReturnTo());
+                    }
+
+                    try {
+                        Mage::dispatchEvent(
+                            'fooman_emailattachments_before_send_queue',
+                            array(
+                                'mailer'            => $mailer,
+                                'message'           => $message,
+                                'mail_transport'    => false
+                            )
+                        );
+                        $mailer->send();
+                    } catch (Exception $e) {
+                        Mage::logException($e);
+                    }
+
+                    unset($mailer);
+                    $message->setProcessedAt(Varien_Date::formatDate(true));
+                    $message->save();
+                } catch (Exception $e) {
+                    Mage::logException($e);
                 }
             }
         }
@@ -151,16 +116,18 @@ class Ebizmarts_MailChimp_Model_Email_Queue extends Mage_Core_Model_Email_Queue
 
     /**
      * @param $storeId
-     * @return Mandrill_Message|Zend_Mail
+     * @return Mandrill_Message|null
      */
-    public function getMail($storeId)
+    public function getMail($storeId = null)
     {
-        if (!Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE, $storeId)) {
+        if (!Mage::helper('mailchimp/mandrill')->isEnabled) {
             return null;
-        }
+        } else {
+            $apiKey = Mage::helper('mailchimp/mandrill')->getMandrillApiKey($storeId);
 
-        Mage::helper('mailchimp/mandrill')->log("store: $storeId API: " . Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_APIKEY, $storeId));
-        $mail = new Mandrill_Message(Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_APIKEY, $storeId));
-        return $mail;
+            Mage::helper('mailchimp/mandrill')->log("store: $storeId API: " . $apiKey);
+            $mail = new Mandrill_Message($apiKey);
+            return $mail;
+        }
     }
 }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Email/Template.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Email/Template.php
@@ -22,7 +22,7 @@ class Ebizmarts_MailChimp_Model_Email_Template extends Mage_Core_Model_Email_Tem
      */
     public function send($email, $name = null, array $variables = array())
     {
-        if (!Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE)) {
+        if (!Mage::helper('mailchimp/mandrill')->isEnabled()) {
             return parent::send($email, $name, $variables);
         }
 
@@ -173,16 +173,16 @@ class Ebizmarts_MailChimp_Model_Email_Template extends Mage_Core_Model_Email_Tem
     public function getMail()
     {
         $storeId = Mage::app()->getStore()->getId();
-        if (!Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE, $storeId)) {
+        if (!Mage::helper('mailchimp/mandrill')->isEnabled($storeId)) {
             return parent::getMail();
         }
 
         if ($this->_mail) {
             return $this->_mail;
         } else {
-            $storeId = Mage::app()->getStore()->getId();
-            Mage::helper('mailchimp/mandrill')->log("store: $storeId API: " . Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_APIKEY, $storeId));
-            $this->_mail = new Mandrill_Message(Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_APIKEY, $storeId));
+            $apiKey = Mage::helper('mailchimp/mandrill')->getMandrillApiKey($storeId);
+            Mage::helper('mailchimp/mandrill')->log("store: $storeId API: " . $apiKey);
+            $this->_mail = new Mandrill_Message($apiKey);
             return $this->_mail;
         }
     }


### PR DESCRIPTION
Fixed #174 by completely refactoring the `Ebizmarts_MailChimp_Model_Email_Queue` class so now it can process all emails within the email queue table (like it was supposed to do) and refactored to DRY up the logic for creating and setting values for the `$mailer` object.