### PR TITLE
Deleting Subscribers from magento admin caused an error

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -164,10 +164,10 @@ class Ebizmarts_MailChimp_Model_Observer
      */
     public function handleSubscriberDeletion(Varien_Event_Observer $observer)
     {
-        $isEnabled = Mage::helper('mailchimp')->getConfigValue(Ebizmarts_MailChimp_Model_Config::GENERAL_ACTIVE);
+        $subscriber = $observer->getEvent()->getSubscriber();
+        $isEnabled = Mage::helper('mailchimp')->isMailChimpEnabled($subscriber->getStoreId());
+        
         if ($isEnabled) {
-            $subscriber = $observer->getEvent()->getSubscriber();
-
             Mage::getModel('mailchimp/api_subscribers')->deleteSubscriber($subscriber);
         }
     }


### PR DESCRIPTION
**Steps to reproduce:**

1. Subscribe user to the newsletter
2. Go to the magento admin, find this subscriber in the Newsletter Subscriber list
3. Try to delete him

**Actual result:**
Fatal error: Call to undefined method Ebizmarts_MailChimp_Helper_Data::getConfigValue()

**Expected result**
Subscriber should be deleted