### PR TITLE
Error in `getBatchResponse` method when `/var/mailchimp` directory does not exist

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
@@ -244,18 +244,20 @@ class Ebizmarts_MailChimp_Model_Api_Batches
             if (isset($response['status']) && $response['status'] == 'finished') {
                 // get the tar.gz file with the results
                 $fileUrl = urldecode($response['response_body_url']);
-                $fileName = $baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId;
-                $fd = fopen($fileName . '.tar.gz', 'w');
-                $ch = curl_init();
-                curl_setopt($ch, CURLOPT_URL, $fileUrl);
-                curl_setopt($ch, CURLOPT_FILE, $fd);
-                curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true); // this will follow redirects
-                $r = curl_exec($ch);
-                curl_close($ch);
-                fclose($fd);
+                $fileName = $baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId . '.tar.gz';
+                if (file_exists($fileName)) {
+                    $fd = fopen($fileName, 'w');
+                    $ch = curl_init();
+                    curl_setopt($ch, CURLOPT_URL, $fileUrl);
+                    curl_setopt($ch, CURLOPT_FILE, $fd);
+                    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true); // this will follow redirects
+                    $r = curl_exec($ch);
+                    curl_close($ch);
+                    fclose($fd);
+                }
                 mkdir($baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId, 0750, true);
                 $archive = new Mage_Archive();
-                $archive->unpack($fileName . '.tar.gz', $baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId);
+                $archive->unpack($fileName, $baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId);
                 $archive->unpack($baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId . '/' . $batchId . '.tar', $baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId);
                 $dir = scandir($baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId);
                 foreach ($dir as $d) {
@@ -266,7 +268,7 @@ class Ebizmarts_MailChimp_Model_Api_Batches
                 }
 
                 unlink($baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId . '/' . $batchId . '.tar');
-                unlink($fileName . '.tar.gz');
+                unlink($fileName);
             }
         } catch (Mailchimp_Error $e) {
             $files['error'] = $e->getFriendlyMessage();

--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
@@ -253,7 +253,7 @@ class Ebizmarts_MailChimp_Model_Api_Batches
                 $r = curl_exec($ch);
                 curl_close($ch);
                 fclose($fd);
-                mkdir($baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId, 0750);
+                mkdir($baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId, 0750, true);
                 $archive = new Mage_Archive();
                 $archive->unpack($fileName . '.tar.gz', $baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId);
                 $archive->unpack($baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId . '/' . $batchId . '.tar', $baseDir . DS . 'var' . DS . 'mailchimp' . DS . $batchId);


### PR DESCRIPTION
## Issue Description
`getBatchResponse` method in `/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php` errors if the archive file does not exist and/or the `var/mailchimp` directory does not exist. This pull request adds an additional check to check if the file exists before the curl execution, and will create `var/mailchimp` if the directory does not already exist.

`var/mailchimp` is created within the setup script, but in certain cases where a live deployment system creates a fresh version of the site each time the website is deployed to production, the setup script is not run and the old data in the `var` directory is not retained.

### Preconditions
Magneto 1.9.3.2
mc-magento 1.1.6

### Expected result:
`getBatchResponse` method in `/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php` runs with no errors.

### Actual result:
`getBatchResponse` method in `/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php` fails with following errors:
```
open(/var/mailchimp/29b406160c.tar.gz): failed to open stream: No such file or directory  in /app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php on line 237
```
```
curl_setopt(): supplied argument is not a valid File-Handle resource  in /app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php on line 240
```
```
fclose() expects parameter 1 to be resource, boolean given  in /app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php on line 244
```
```
Warning: mkdir(): No such file or directory  in /app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php on line 245
```