### PR TITLE
Make Travis pass basic test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 app/code/community/Ebizmarts/MailChimp/controllers/TestController.php
+composer.lock
+/vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,23 @@ php:
   - 7.0
 
 env:
-  - TEST_SUITE=marketplate_eqp
-  - TEST_SUITE=ecg_coding_standards
+  global:
+    - COMPOSER_BIN_DIR=~/bin
+  matrix:
+    - CODING_STANDARD=Ecg SEVERITY=5
+    - CODING_STANDARD=MEQP1 SEVERITY=5
+    - CODING_STANDARD=MEQP1 SEVERITY=9
 
-before_script:
-  - sleep 30
+matrix:
+  allow_failures:
+    - env: CODING_STANDARD=Ecg SEVERITY=5
+    - env: CODING_STANDARD=MEQP1 SEVERITY=5
 
-script:
-  - cd ..
-  - sh -c "if [ '$TEST_SUITE' = 'marketplate_eqp' ]; then composer config --global repositories.magento-eqp git https://github.com/magento/marketplace-eqp && composer require magento/marketplace-eqp && vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set installed_paths /home/travis/build/mailchimp/vendor/magento/marketplace-eqp/ && vendor/squizlabs/php_codesniffer/scripts/phpcs -n --standard="MEQP1" ./mc-magento/; fi"
-  - sh -c "if [ '$TEST_SUITE' = 'ecg_coding_standards' ]; then composer require magento-ecg/coding-standard && composer require squizlabs/php_codesniffer && vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set installed_paths /home/travis/build/mailchimp/vendor/magento-ecg/coding-standard && vendor/squizlabs/php_codesniffer/scripts/phpcs -n --standard="Ecg" ./mc-magento/; fi"
+before_install: test -n "$GITHUB_TOKEN" && composer config github-oauth.github.com "$GITHUB_TOKEN" || true
+install: composer install --no-interaction --prefer-dist
+
+before_script: phpcs --config-set installed_paths vendor/magento-ecg/coding-standard,vendor/magento/marketplace-eqp
+script: phpcs ./ --ignore=./vendor --standard="$CODING_STANDARD" --severity="$SEVERITY" --extensions=phtml,php,js,css
 
 #notifications:
 #  slack: ebizmarts:DqCqxnqWzW55zoFU069hxs1T

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MailChimp For Magento 1
+[![Build Status](https://travis-ci.org/mailchimp/mc-magento.svg?branch=develop)](https://travis-ci.org/mailchimp/mc-magento)
 
 Integration to sync all the Magento data (Newsletter subscriber, Customers, Orders, Products) with MailChimp. It allows to use all the MailChimp potential for email Marketing such as sending Campaigns, Automations and more.
 

--- a/app/code/community/Ebizmarts/MailChimp/Model/Email/TemplateBase.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Email/TemplateBase.php
@@ -2,15 +2,11 @@
 if (Mage::helper('core')->isModuleEnabled('Aschroder_SMTPPro')
     && class_exists('Aschroder_SMTPPro_Model_Email_Template')
 ) {
-    class Ebizmarts_MailChimp_Model_Email_TemplateBase extends Aschroder_SMTPPro_Model_Email_Template
-    {
-    }
+    class_alias('Aschroder_SMTPPro_Model_Email_Template', 'Ebizmarts_MailChimp_Model_Email_TemplateBase');
 } elseif (Mage::helper('core')->isModuleEnabled('Aschroder_Email')
     && class_exists('Aschroder_Email_Model_Email_Template')
 ) {
-    class Ebizmarts_MailChimp_Model_Email_TemplateBase extends Aschroder_Email_Model_Email_Template
-    {
-    }
+    class_alias('Aschroder_Email_Model_Email_Template', 'Ebizmarts_MailChimp_Model_Email_TemplateBase');
 } else {
     class Ebizmarts_MailChimp_Model_Email_TemplateBase extends Mage_Core_Model_Email_Template
     {

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,17 @@
             "email": "mailchimp@ebizmarts-desk.zendesk.com"
         }
     ],
-    "require": {
-        "magento-hackathon/magento-composer-installer": "*"
+    "suggest": {
+        "magento-hackathon/magento-composer-installer": "Map/copy module files with your Magento installation"
+    },
+    "require-dev": {
+        "magento-ecg/coding-standard": "^2.0",
+        "magento/marketplace-eqp": "^1.0"
     },
     "repositories": [
         {
-            "type": "composer",
-            "url": "https://packages.firegento.com"
+            "type": "vcs",
+            "url": "https://github.com/magento/marketplace-eqp.git"
         }
     ]
 }


### PR DESCRIPTION
Make Travis CI able to pass while still running strict tests.

Also contains [commit](087aec7983f4c9474da382ff6df3b84e0b1b5c0b) that makes the module able to pass Magento [Marketplace Technical Review](https://github.com/magento/marketplace-eqp/tree/c82070eca1075569578206430a6ef7975f7eeec1#marketplace-technical-review) minimum demands

To avoid GitHub's API rate limit a token can be generated ([link](https://github.com/settings/tokens/new?scopes=repo)) and given as a environment variable named `GITHUB_TOKEN`.

Thanks to @centerax for laying the groundwork with his Travis config