### PR TITLE
Validating tax_total and shipping_total

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Orders.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Orders.php
@@ -186,9 +186,9 @@ class Ebizmarts_MailChimp_Model_Api_Orders
 
         $data['currency_code'] = $order->getOrderCurrencyCode();
         $data['order_total'] = $order->getGrandTotal();
-        $data['tax_total'] = $order->getTaxAmount();
+        $data['tax_total'] = $order->getTaxAmount()==null?0:$order->getTaxAmount();
         $data['discount_total'] = abs($order->getDiscountAmount());
-        $data['shipping_total'] = $order->getShippingAmount();
+        $data['shipping_total'] = $order->getShippingAmount()==null?0:$order->getShippingAmount();
         $statusArray = $this->_getMailChimpStatus($order);
         if (isset($statusArray['financial_status'])) {
             $data['financial_status'] = $statusArray['financial_status'];

--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Orders.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Orders.php
@@ -186,7 +186,7 @@ class Ebizmarts_MailChimp_Model_Api_Orders
 
         $data['currency_code'] = $order->getOrderCurrencyCode();
         $data['order_total'] = $order->getGrandTotal();
-        $data['tax_total'] = $order->getTaxAmount()==null?0:$order->getTaxAmount();
+        $data['tax_total'] = $this->returnZeroIfNull($this->getTaxAmount());
         $data['discount_total'] = abs($order->getDiscountAmount());
         $data['shipping_total'] = $order->getShippingAmount()==null?0:$order->getShippingAmount();
         $statusArray = $this->_getMailChimpStatus($order);
@@ -435,6 +435,15 @@ class Ebizmarts_MailChimp_Model_Api_Orders
         return $jsonData;
     }
 
+    protected function returnZeroIfNull($value)
+    {
+        $returnValue = $value;
+        if ($value === null) {
+            $returnValue = 0;
+        }
+        return $returnValue;
+    }
+    
     protected function _getMailChimpStatus($order)
     {
         $mailChimpFinancialStatus = null;

--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Orders.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Orders.php
@@ -186,9 +186,9 @@ class Ebizmarts_MailChimp_Model_Api_Orders
 
         $data['currency_code'] = $order->getOrderCurrencyCode();
         $data['order_total'] = $order->getGrandTotal();
-        $data['tax_total'] = $this->returnZeroIfNull($this->getTaxAmount());
+        $data['tax_total'] = $this->returnZeroIfNull($order->getTaxAmount());
         $data['discount_total'] = abs($order->getDiscountAmount());
-        $data['shipping_total'] = $order->getShippingAmount()==null?0:$order->getShippingAmount();
+        $data['shipping_total'] = $this->returnZeroIfNull($order->getShippingAmount());
         $statusArray = $this->_getMailChimpStatus($order);
         if (isset($statusArray['financial_status'])) {
             $data['financial_status'] = $statusArray['financial_status'];


### PR DESCRIPTION
 if they are stored as null make them return 0 instead. MailChimp does not like NULL values.

For some reason, on older install of Magento 1, the tax_total and shipping_total can be set as NULL if there isn't tax or shipping. Don't ask me why. I've run into this enough, thissimple check should solve many people's headaches.