### PR TITLE
Correcting class name reference

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
@@ -260,7 +260,7 @@ class Ebizmarts_MailChimp_Model_Api_Batches
      */
     protected function _sendSubscriberBatches()
     {
-        $subscriberLimit = Ebizmarts_MailChimp_Model_Api_subscribers::BATCH_LIMIT;
+        $subscriberLimit = Ebizmarts_MailChimp_Model_Api_Subscribers::BATCH_LIMIT;
         $stores = Mage::app()->getStores();
         $batchResponses = array();
         foreach ($stores as $store) {


### PR DESCRIPTION
The way the code currently is, there is no issue since Magento's autoloader handles improperly cased class names. However, we use a custom autoloader that is a little more strict about the accuracy of class name references. It would be great to ensure the class name references are accurate.

I did a quick search over the codebase for other examples but this was the only one I found.