### PR TITLE
Switched newsletter subscriber event listener from before to after

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/etc/config.xml
+++ b/app/code/community/Ebizmarts/MailChimp/etc/config.xml
@@ -19,14 +19,14 @@
                     </mailchimp_change_store_name>
                 </observers>
             </store_group_save>
-            <newsletter_subscriber_save_before>
+            <newsletter_subscriber_save_after>
                 <observers>
                     <mailchimp_subscribe_observer>
                         <class>mailchimp/observer</class>
                         <method>handleSubscriber</method>
                     </mailchimp_subscribe_observer>
                 </observers>
-            </newsletter_subscriber_save_before>
+            </newsletter_subscriber_save_after>
             <newsletter_subscriber_delete_after>
                 <observers>
                     <mailchimp_subscribe_delete_observer>


### PR DESCRIPTION
The problem with listening on before is that other modules might have issues with appending data to the subscriber object before it is processed my the mailchimp module.

By changing from ```newsletter_subscriber_save_before``` to ```newsletter_subscriber_save_after``` have the chans to append data to the object and that data can later be used when the subscriber is send to mailchimp.