### PR TITLE
Added event dispatch after merge of variables for subscriber sync

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Subscribers.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Subscribers.php
@@ -296,6 +296,20 @@ class Ebizmarts_MailChimp_Model_Api_Subscribers
             }
         }
 
+        $newVars = new Varien_Object;
+
+        Mage::dispatchEvent(
+            'mailchimp_mergevars_after', array(
+                'subscriber' => $subscriber,
+                'vars' => $mergeVars,
+                'new_vars' => $newVars
+            )
+        );
+
+        if ($newVars->hasData()) {
+            $mergeVars = array_merge($mergeVars, $newVars->getData());
+        }
+
         return (!empty($mergeVars)) ? $mergeVars : null;
     }
 


### PR DESCRIPTION
Currently there is only one dispatch job that is triggered incrementally for each pre-defined value. You can not append data to the array without overriding any function.

This change will dispatch an event to the end of the ```getMergeVars``` function and give the possibility to have more dynamic data inside the array.