### PR TITLE
Fix for MC API error "Invalid Resource for Api Call"

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Subscribers.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Subscribers.php
@@ -130,6 +130,19 @@ class Ebizmarts_MailChimp_Model_Api_Subscribers
         $subscriberEmail = $subscriber->getSubscriberEmail();
         $customer = Mage::getModel('customer/customer')->setWebsiteId($websiteId)->loadByEmail($subscriberEmail);
 
+        $customerFirstname = '';
+        $customerLastname = '';
+        if (!Mage::getSingleton('customer/session')->isLoggedIn() ) {
+            $session = Mage::getSingleton('checkout/session');
+            $quote_id = $session->getQuoteId();
+            if ($quote_id) {
+                $quote = Mage::getModel('sales/quote')->load($quote_id);
+                $data = $quote->getData();
+                $customerFirstname = $data['customer_firstname'];
+                $customerLastname = $data['customer_lastname'];
+            }
+        }
+
         foreach ($maps as $map) {
             $customAtt = $map['magento'];
             $chimpTag = $map['mailchimp'];
@@ -175,6 +188,9 @@ class Ebizmarts_MailChimp_Model_Api_Subscribers
 
                                     if (!$firstName) {
                                         $firstName = $subscriber->getSubscriberFirstname();
+                                        if (empty($firstName)) {
+                                            $firstName = $customerFirstname;
+                                        }
                                     }
 
                                     if ($firstName) {
@@ -186,6 +202,9 @@ class Ebizmarts_MailChimp_Model_Api_Subscribers
 
                                     if (!$lastName) {
                                         $lastName = $subscriber->getSubscriberLastname();
+                                        if (empty($lastName)) {
+                                            $lastName = $customerLastname;
+                                        }
                                     }
 
                                     if ($lastName) {


### PR DESCRIPTION
When logged-out visitor (not customer) on onepage checkout enable 'Subscribe to Newsletter' checkbox, on checkout success page he get Mailchimp error with message

> Invalid Resource for Api Call: lists/64******34/members/3e****************************7c : FNAME : Please enter a value

And contact in Mailchimp have empty First and Last name fields.

This patch should resolve that.