### PR TITLE
Adding ability to change email address in Magento, unsubscribe old em…

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Subscribers.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Subscribers.php
@@ -124,7 +124,7 @@ class Ebizmarts_MailChimp_Model_Api_Subscribers
             ->getData();
         $mergeVars = array();
         $subscriberEmail = $subscriber->getSubscriberEmail();
-        $customer = Mage::getModel('customer/customer')->setWebsiteId($websiteId)->loadByEmail($subscriberEmail);
+        $customer = Mage::getModel('customer/customer')->setWebsiteId($websiteId)->load($subscriber->getCustomerId());
 
         foreach ($maps as $map) {
             $customAtt = $map['magento'];

--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -143,7 +143,7 @@ class Ebizmarts_MailChimp_Model_Observer
                 $subscriber = Mage::getModel('newsletter/subscriber')->loadByCustomer($customer);
                 $subscriber->setSubscriberEmail($customer->getEmail()); // make sure we set the new email address
 
-                $response = Mage::getModel('mailchimp/api_subscribers')->updateSubscriber($subscriber, true);
+                Mage::getModel('mailchimp/api_subscribers')->updateSubscriber($subscriber, true);
             }
         }
 


### PR DESCRIPTION
…ail in MC and subscribe new one

In our Magento site we allow customers to change their email addresses. I noticed that the old email address is not unsubscribed (impacting our reputation because we will always be sending email to the old email) and the new email is never subscribed (not good for marketing)

I believe this issue could refer to the same issue fixed in this PR
https://github.com/mailchimp/mc-magento/issues/17