### PR TITLE
Removes exception in order grid if for example a used payment method has been disabled

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Sales/Order/Grid/Renderer/Mailchimp.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Sales/Order/Grid/Renderer/Mailchimp.php
@@ -14,13 +14,18 @@ class Ebizmarts_MailChimp_Block_Adminhtml_Sales_Order_Grid_Renderer_Mailchimp ex
 {
     public function render(Varien_Object $row)
     {
-        $order = Mage::getModel('sales/order')->load($row->getData('entity_id'));
-        if ($order->getMailchimpAbandonedcartFlag() || $order->getMailchimpCampaignId()) {
-            $result = '<img src="' . $this->getSkinUrl("ebizmarts/mailchimp/images/logo-freddie-monocolor-200.png") . '" width="40" title="hep hep thanks MailChimp" />';
-        } else {
-            $result = '';
+        $result = '';
+
+        try {
+            $order = Mage::getModel('sales/order')->load($row->getData('entity_id'));
+
+            if ($order->getMailchimpAbandonedcartFlag() || $order->getMailchimpCampaignId()) {
+                $result = '<img src="' . $this->getSkinUrl("ebizmarts/mailchimp/images/logo-freddie-monocolor-200.png") . '" width="40" title="hep hep thanks MailChimp" />';
+            }
+        } catch (Exception $e) {
         }
 
         return $result;
     }
 }
+


### PR DESCRIPTION
Due to you are loading each order for each row in the order grid you might case as exception.
Magento throws by default an exception if you load a order which has used a payment method that has been disabled or been removed. Due to the search filter is saved in the session you will not be able to visit the order list any more due to it will constantly throw the same exception until the session is cleared. 