### PR TITLE
Added Mailchimperrors grid column ID

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Mailchimperrors/Grid.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Mailchimperrors/Grid.php
@@ -44,6 +44,13 @@ class Ebizmarts_MailChimp_Block_Adminhtml_Mailchimperrors_Grid extends Mage_Admi
         //            'sortable' => true
         //        ));
         $this->addColumn(
+            'id', array(
+            'header' => Mage::helper('mailchimp')->__('ID'),
+            'index' => 'id',
+            'sortable' => true
+            )
+        );
+        $this->addColumn(
             'title', array(
             'header' => Mage::helper('mailchimp')->__('Title'),
             'index' => 'title',


### PR DESCRIPTION
If you don't add this grid column ID, you won't be able to sort by ID to find latest or oldest one. I can see 58K errors and there is no way to find latest unless you go to database.