### PR TITLE
add guest checkout name to subscriber data

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -303,6 +303,10 @@ class Ebizmarts_MailChimp_Model_Observer
                 $email = $order->getCustomerEmail();
                 $subscriber = $helper->loadListSubscriber($post, $email);
                 if ($subscriber) {
+                    if(!$subscriber->getCustomerId()) {
+                        $subscriber->setSubscriberFirstname($order->getCustomerFirstname());
+                        $subscriber->setSubscriberLastname($order->getCustomerLastname());
+                    }
                     $helper->subscribeMember($subscriber, true);
                 }
             }

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
@@ -461,7 +461,6 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
         $productId = 1;
         $mailchimpStoreId = 'a1s2d3f4g5h6j7k8l9n0';
         $customerEmail = 'email@example.com';
-        $customerId = 1;
         $customerFirstname = 'John';
         $customerLastname = 'Smith';
 
@@ -533,7 +532,7 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $helperMock->expects($this->once())->method('loadListSubscriber')->with($post, $customerEmail)->willReturn($subscriberMock);
 
-        $subscriberMock->expects($this->once())->method('getCustomerId')->willReturn($customerId);
+        $subscriberMock->expects($this->once())->method('getCustomerId')->willReturn(false);
 
         $orderMock->expects($this->once())->method('getCustomerFirstname')->willReturn($customerFirstname);
 

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
@@ -461,6 +461,9 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
         $productId = 1;
         $mailchimpStoreId = 'a1s2d3f4g5h6j7k8l9n0';
         $customerEmail = 'email@example.com';
+        $customerId = 1;
+        $customerFirstname = 'John';
+        $customerLastname = 'Smith';
 
 
         $itemMock = $this->getMockBuilder(Mage_Sales_Model_Order_Item::class)
@@ -470,7 +473,7 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $orderMock = $this->getMockBuilder(Mage_Sales_Model_Order::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getStoreId', 'getCustomerEmail', 'getAllItems'))
+            ->setMethods(array('getStoreId', 'getCustomerEmail', 'getCustomerFirstname', 'getCustomerLastname', 'getAllItems'))
             ->getMock();
 
         $eventObserverMock = $this->getMockBuilder(Varien_Event_Observer::class)
@@ -506,6 +509,7 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $subscriberMock = $this->getMockBuilder(Mage_Newsletter_Model_Subscriber::class)
             ->disableOriginalConstructor()
+            ->setMethods(array('getCustomerId', 'setSubscriberFirstname', 'setSubscriberLastname'))
             ->getMock();
 
         $observerMock->expects($this->once())->method('makeHelper')->willReturn($helperMock);
@@ -528,6 +532,16 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
         $orderMock->expects($this->once())->method('getCustomerEmail')->willReturn($customerEmail);
 
         $helperMock->expects($this->once())->method('loadListSubscriber')->with($post, $customerEmail)->willReturn($subscriberMock);
+
+        $subscriberMock->expects($this->once())->method('getCustomerId')->willReturn($customerId);
+
+        $orderMock->expects($this->once())->method('getCustomerFirstname')->willReturn($customerFirstname);
+
+        $subscriberMock->expects($this->once())->method('setSubscriberFirstname')->with($customerFirstname);
+
+        $orderMock->expects($this->once())->method('getCustomerLastname')->willReturn($customerLastname);
+
+        $subscriberMock->expects($this->once())->method('setSubscriberLastname')->with($customerLastname);
 
         $helperMock->expects($this->once())->method('subscribeMember')->with($subscriberMock, true);
 


### PR DESCRIPTION
Check if checkout subscriber ist no returning customer (has no customer id), then add the first+lastname to the subscriber data.