### PR TITLE
Closes Issue668

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Block/Popup/Emailcatcher.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Popup/Emailcatcher.php
@@ -73,8 +73,7 @@ class Ebizmarts_MailChimp_Block_Popup_Emailcatcher extends Mage_Core_Block_Templ
                     $subscriber->setSubscriberLastname($subscriberLname);
                 }
 
-                $subscriber->setStoreId($storeId)
-                    ->subscribe($email);
+                $subscriber->subscribe($email);
                 return 'location.reload';
             }
         }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -307,7 +307,8 @@ class Ebizmarts_MailChimp_Model_Observer
                         $subscriber->setSubscriberFirstname($order->getCustomerFirstname());
                         $subscriber->setSubscriberLastname($order->getCustomerLastname());
                     }
-                    $helper->subscribeMember($subscriber, true);
+                    $subscriber->setStoreId($storeId)
+                        ->subscribe($email);
                 }
             }
         }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -307,8 +307,7 @@ class Ebizmarts_MailChimp_Model_Observer
                         $subscriber->setSubscriberFirstname($order->getCustomerFirstname());
                         $subscriber->setSubscriberLastname($order->getCustomerLastname());
                     }
-                    $subscriber->setStoreId($storeId)
-                        ->subscribe($email);
+                    $subscriber->subscribe($email);
                 }
             }
         }

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
@@ -507,7 +507,7 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $subscriberMock = $this->getMockBuilder(Mage_Newsletter_Model_Subscriber::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getCustomerId', 'setSubscriberFirstname', 'setSubscriberLastname', 'setStoreId', 'subscribe'))
+            ->setMethods(array('getCustomerId', 'setSubscriberFirstname', 'setSubscriberLastname', 'subscribe'))
             ->getMock();
 
         $observerMock->expects($this->once())->method('makeHelper')->willReturn($helperMock);
@@ -540,8 +540,6 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
         $orderMock->expects($this->once())->method('getCustomerLastname')->willReturn($customerLastname);
 
         $subscriberMock->expects($this->once())->method('setSubscriberLastname')->with($customerLastname);
-
-        $subscriberMock->expects($this->once())->method('setStoreId')->with($storeId);
 
         $subscriberMock->expects($this->once())->method('subscribe')->with($customerEmail);
 

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
@@ -492,8 +492,7 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $helperMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getMageApp', 'isEcomSyncDataEnabled', 'isSubscriptionEnabled', 'loadListSubscriber', 'subscribeMember',
-                'saveEcommerceSyncData', 'getMCStoreId'))
+            ->setMethods(array('getMageApp', 'isEcomSyncDataEnabled', 'isSubscriptionEnabled', 'loadListSubscriber', 'saveEcommerceSyncData', 'getMCStoreId'))
             ->getMock();
 
         $mageAppMock = $this->getMockBuilder(Mage_Core_Model_App::class)
@@ -508,7 +507,7 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $subscriberMock = $this->getMockBuilder(Mage_Newsletter_Model_Subscriber::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getCustomerId', 'setSubscriberFirstname', 'setSubscriberLastname'))
+            ->setMethods(array('getCustomerId', 'setSubscriberFirstname', 'setSubscriberLastname', 'setStoreId', 'subscribe'))
             ->getMock();
 
         $observerMock->expects($this->once())->method('makeHelper')->willReturn($helperMock);
@@ -542,7 +541,9 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $subscriberMock->expects($this->once())->method('setSubscriberLastname')->with($customerLastname);
 
-        $helperMock->expects($this->once())->method('subscribeMember')->with($subscriberMock, true);
+        $subscriberMock->expects($this->once())->method('setStoreId')->with($storeId);
+
+        $subscriberMock->expects($this->once())->method('subscribe')->with($customerEmail);
 
         $observerMock->expects($this->once())->method('removeCampaignData');
 


### PR DESCRIPTION
Closes Issue #668. Use the default Magento method to subscribe checkout subscriber and not the one for the webhook.
Small Fix: setStoreId was called twice in _handleCookie function. Removed one.