### PR TITLE
Update Observer.php

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -247,7 +247,9 @@ class Ebizmarts_MailChimp_Model_Observer
                     $subscriber = $subscriberModel->loadByCustomer($customer);
                     $subscriber->setSubscriberEmail($customerEmail); // make sure we set the new email address
 
-                    $apiSubscriber->updateSubscriber($subscriber, true);
+                    if ($subscriber->getId()) {
+                        $apiSubscriber->updateSubscriber($subscriber, true);
+                    }
                 }
             }
             //update subscriber data if a subscriber with the same email address exists


### PR DESCRIPTION
When I try change emails of our customers.

Return this ...

Invalid Resource for Api Call: lists/d30193f423/members/3c276bd85bb443e77bbdc7f0c10e6895 : status_if_new : Schema describes string, NULL found instead / merge_fields.WEBSITE : Data did not match any of the schemas described in anyOf. / merge_fields.STOREID : Data did not match any of the schemas described in anyOf. / merge_fields.STORECODE : Data did not match any of the schemas described in anyOf.