### PR TITLE
Catch exception if mandrill api is not available

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Email/Template.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Email/Template.php
@@ -230,7 +230,13 @@ class Ebizmarts_MailChimp_Model_Email_Template extends Ebizmarts_MailChimp_Model
      */
     protected function getSendersDomains($mail)
     {
-        return $mail->senders->domains();
+        $mandrillSenders = arrray();
+        try {
+            $mandrillSenders = $mail->senders->domains();
+        } catch (Exception $e) {
+            Mage::logException($e);
+        }
+        return $mandrillSenders;
     }
 
     /**


### PR DESCRIPTION
If the mandrill api is not available the class Mandrill_Mandrill throws a Mandrill_Error in line 159 which is not being caught.
This commit catches the exception.