### PR TITLE
Add option to not send Promo Rules and Promo Codes

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
@@ -3139,4 +3139,9 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
     {
         return (bool)$this->getConfigValueForScope(Mage_Newsletter_Model_Subscriber::XML_PATH_CONFIRMATION_FLAG, $scopeId, $scope);
     }
+
+    public function getPromoConfig($scopeId, $scope = null)
+    {
+        return $this->getConfigValueForScope(Ebizmarts_MailChimp_Model_Config::ECOMMERCE_SEND_PROMO, $scopeId, $scope);
+    }
 }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
@@ -11,6 +11,8 @@
  */
 class Ebizmarts_MailChimp_Model_Api_Batches
 {
+    const SEND_PROMO_ENABLED = 1;
+
     /**
      * @var Ebizmarts_MailChimp_Helper_Data
      */
@@ -320,17 +322,19 @@ class Ebizmarts_MailChimp_Model_Api_Batches
                 $ordersArray = $apiOrders->createBatchJson($mailchimpStoreId, $magentoStoreId);
                 $orderAmount = count($ordersArray);
                 $batchArray['operations'] = array_merge($batchArray['operations'], $ordersArray);
-                //promo rule operations
-                $apiPromoRules = $this->getApiPromoRules();
-                $promoRulesArray = $apiPromoRules->createBatchJson($mailchimpStoreId, $magentoStoreId);
-                $batchArray['operations'] = array_merge($batchArray['operations'], $promoRulesArray);
-                //promo code operations
-                $apiPromoCodes = $this->getApiPromoCodes();
-                $promoCodesArray = $apiPromoCodes->createBatchJson($mailchimpStoreId, $magentoStoreId);
-                $batchArray['operations'] = array_merge($batchArray['operations'], $promoCodesArray);
-//                //deleted product operations
-                $deletedProductsArray = $apiProducts->createDeletedProductsBatchJson($mailchimpStoreId, $magentoStoreId);
-                $batchArray['operations'] = array_merge($batchArray['operations'], $deletedProductsArray);
+                if ($helper->getPromoConfig($magentoStoreId) == self::SEND_PROMO_ENABLED) {
+                    //promo rule operations
+                    $apiPromoRules = $this->getApiPromoRules();
+                    $promoRulesArray = $apiPromoRules->createBatchJson($mailchimpStoreId, $magentoStoreId);
+                    $batchArray['operations'] = array_merge($batchArray['operations'], $promoRulesArray);
+                    //promo code operations
+                    $apiPromoCodes = $this->getApiPromoCodes();
+                    $promoCodesArray = $apiPromoCodes->createBatchJson($mailchimpStoreId, $magentoStoreId);
+                    $batchArray['operations'] = array_merge($batchArray['operations'], $promoCodesArray);
+                    //deleted product operations
+                    $deletedProductsArray = $apiProducts->createDeletedProductsBatchJson($mailchimpStoreId, $magentoStoreId);
+                    $batchArray['operations'] = array_merge($batchArray['operations'], $deletedProductsArray);
+                }
                 $batchJson = null;
                 $batchResponse = null;
 

--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
@@ -331,10 +331,10 @@ class Ebizmarts_MailChimp_Model_Api_Batches
                     $apiPromoCodes = $this->getApiPromoCodes();
                     $promoCodesArray = $apiPromoCodes->createBatchJson($mailchimpStoreId, $magentoStoreId);
                     $batchArray['operations'] = array_merge($batchArray['operations'], $promoCodesArray);
+                }
                     //deleted product operations
                     $deletedProductsArray = $apiProducts->createDeletedProductsBatchJson($mailchimpStoreId, $magentoStoreId);
                     $batchArray['operations'] = array_merge($batchArray['operations'], $deletedProductsArray);
-                }
                 $batchJson = null;
                 $batchResponse = null;
 

--- a/app/code/community/Ebizmarts/MailChimp/Model/Config.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Config.php
@@ -52,6 +52,7 @@ class Ebizmarts_MailChimp_Model_Config
     const ECOMMERCE_ORDER_AMOUNT        = 'mailchimp/ecommerce/order_batch_amount';
     const ECOMMERCE_IMAGE_SIZE          = 'mailchimp/ecommerce/image_size';
     const ECOMMERCE_SYNC_DATE           = 'mailchimp/ecommerce/sync_date';
+    const ECOMMERCE_SEND_PROMO          = 'mailchimp/ecommerce/send_promo';
 
     const IMAGE_SIZE_DEFAULT            = 'image';
     const IMAGE_SIZE_SMALL              = 'small_image';

--- a/app/code/community/Ebizmarts/MailChimp/etc/system.xml
+++ b/app/code/community/Ebizmarts/MailChimp/etc/system.xml
@@ -268,6 +268,18 @@
                                 <active>1</active>
                             </depends>
                         </firstdate>
+                        <send_promo translate="label">
+                            <label>Send Promo Rules and Promo Codes</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>215</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                        </send_promo>
                         <reset_ecommerce_data translate="label comment">
                             <frontend_type>button</frontend_type>
                             <frontend_model>mailchimp/adminhtml_system_config_resetEcommerceData</frontend_model>

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/BatchesTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/BatchesTest.php
@@ -257,13 +257,21 @@ class Ebizmarts_MailChimp_Model_Api_BatchesTest extends PHPUnit_Framework_TestCa
         );
     }
 
-    public function testSendEcommerceBatch()
+    /**
+     * @param array $data
+     * @dataProvider sendEcommerceBatchDataProvider
+     */
+
+    public function testSendEcommerceBatch($data)
     {
         $mailchimpStoreId = 'ef3bf57fb9bd695a02b7f7c7fb0d2db5';
         $magentoStoreId = 1;
         $syncingFlag = '2018-02-01 00:00:00';
         $ecomSyncDateFlag = '2018-02-02 00:00:00';
         $configValue = array(array(Ebizmarts_MailChimp_Model_Config::GENERAL_MCISSYNCING, 1));
+        $sendPromo = $data['sendPromo'];
+        $batchArray = array();
+        $batchArray['operations'] = $data['batchArray'];
 
         $customerArray = $this->getCustomerArray();
 
@@ -279,15 +287,7 @@ class Ebizmarts_MailChimp_Model_Api_BatchesTest extends PHPUnit_Framework_TestCa
 
         $promoCodesArray = $this->getPromoCodeArray();
 
-        //merge arrays and encode
-        $batchArray = array();
-        $batchArray['operations'] = $customerArray;
-        $batchArray['operations'] = array_merge($batchArray['operations'], $productsArray);
-        $batchArray['operations'] = array_merge($batchArray['operations'], $cartsArray);
-        $batchArray['operations'] = array_merge($batchArray['operations'], $ordersArray);
-        $batchArray['operations'] = array_merge($batchArray['operations'], $promoRulesArray);
-        $batchArray['operations'] = array_merge($batchArray['operations'], $promoCodesArray);
-        $batchArray['operations'] = array_merge($batchArray['operations'], $deletedProductsArray);
+        //encode merged arrays
 
         $batchJson = json_encode($batchArray);
 
@@ -305,7 +305,7 @@ class Ebizmarts_MailChimp_Model_Api_BatchesTest extends PHPUnit_Framework_TestCa
         $helperMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
             ->disableOriginalConstructor()
             ->setMethods(array('getMCStoreId', 'getEcommMinSyncDateFlag', 'isEcomSyncDataEnabled', 'getApi',
-                'getMCIsSyncing', 'logRequest', 'validateDate', 'saveMailchimpConfig'))
+                'getMCIsSyncing', 'logRequest', 'validateDate', 'saveMailchimpConfig', 'getPromoConfig'))
             ->getMock();
 
         $apiCustomersMock = $this->getMockBuilder(Ebizmarts_MailChimp_Model_Api_Customers::class)
@@ -375,13 +375,14 @@ class Ebizmarts_MailChimp_Model_Api_BatchesTest extends PHPUnit_Framework_TestCa
         $apiBatchesMock->expects($this->once())->method('getApiOrders')->willReturn($apiOrdersMock);
         $apiOrdersMock->expects($this->once())->method('createBatchJson')->with($mailchimpStoreId, $magentoStoreId)->willReturn($ordersArray);
 
-        $apiBatchesMock->expects($this->once())->method('getApiPromoRules')->willReturn($apiPromoRulesMock);
-        $apiPromoRulesMock->expects($this->once())->method('createBatchJson')->with($mailchimpStoreId, $magentoStoreId)->willReturn($promoRulesArray);
+        $apiBatchesMock->expects($this->exactly($sendPromo))->method('getApiPromoRules')->willReturn($apiPromoRulesMock);
+        $apiPromoRulesMock->expects($this->exactly($sendPromo))->method('createBatchJson')->with($mailchimpStoreId, $magentoStoreId)->willReturn($promoRulesArray);
 
-        $apiBatchesMock->expects($this->once())->method('getApiPromoCodes')->willReturn($apiPromoCodesMock);
-        $apiPromoCodesMock->expects($this->once())->method('createBatchJson')->with($mailchimpStoreId, $magentoStoreId)->willReturn($promoCodesArray);
+        $apiBatchesMock->expects($this->exactly($sendPromo))->method('getApiPromoCodes')->willReturn($apiPromoCodesMock);
+        $apiPromoCodesMock->expects($this->exactly($sendPromo))->method('createBatchJson')->with($mailchimpStoreId, $magentoStoreId)->willReturn($promoCodesArray);
 
         $helperMock->expects($this->once())->method('getApi')->with($magentoStoreId)->willReturn($apiMock);
+        $helperMock->expects($this->once())->method('getPromoConfig')->with($magentoStoreId)->willReturn($sendPromo);
 
         $apiMock->expects($this->once())->method('getBatchOperation')->willReturn($apiBatchOperationMock);
         $apiBatchOperationMock->expects($this->once())->method('add')->with($batchJson)->willReturn($batchResponse);
@@ -403,6 +404,31 @@ class Ebizmarts_MailChimp_Model_Api_BatchesTest extends PHPUnit_Framework_TestCa
 
 
         $apiBatchesMock->_sendEcommerceBatch($magentoStoreId);
+    }
+
+    //merge batch arrays including or excluding promo rules/promo codes based on the setting
+    public function sendEcommerceBatchDataProvider()
+    {
+        $batchArray = array();
+
+        return array(
+            array(array('sendPromo' => 0,
+                'customerArray' => $batchArray['operations'] = $this->getCustomerArray(),
+                'productsArray' => $batchArray['operations'] = array_merge($batchArray['operations'], $this->getProductArray()),
+                'cartsArray' => $batchArray['operations'] = array_merge($batchArray['operations'], $this->getCartArray()),
+                'ordersArray' => $batchArray['operations'] = array_merge($batchArray['operations'], $this->getOrderArray()),
+                'deletedProductsArray' => $batchArray['operations'] = array_merge($batchArray['operations'], $this->getDeletedProductArray()),
+                'batchArray' => $batchArray['operations'])),
+            array(array('sendPromo' => 1,
+                'customerArray' => $batchArray['operations'] = $this->getCustomerArray(),
+                'productsArray' => $batchArray['operations'] = array_merge($batchArray['operations'], $this->getProductArray()),
+                'cartsArray' => $batchArray['operations'] = array_merge($batchArray['operations'], $this->getCartArray()),
+                'ordersArray' => $batchArray['operations'] = array_merge($batchArray['operations'], $this->getOrderArray()),
+                'promoRulesArray' => $batchArray['operations'] = array_merge($batchArray['operations'], $this->getPromoRuleArray()),
+                'promoCodesArray' => $batchArray['operations'] = array_merge($batchArray['operations'], $this->getPromoCodeArray()),
+                'deletedProductsArray' => $batchArray['operations'] = array_merge($batchArray['operations'], $this->getDeletedProductArray()),
+                'batchArray' => $batchArray['operations'])),
+        );
     }
 
     public function testGetResults()


### PR DESCRIPTION
- Add setting in admin configuration to not send Promo Codes and Promo Rules with the rest of the ecommerce data.
- Added new use case to unit test.