### PR TITLE
#834 Add option to send unresized product images to Mailchimp

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
@@ -1329,11 +1329,20 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
         } else {
             $curStore = $this->getCurrentStoreId();
             $this->setCurrentStore($magentoStoreId);
-            $upperCaseImage = $this->getImageFunctionName($imageSize);
-            $imageUrl = $productModel->$upperCaseImage();
+            if ($configImageSize == 3){
+                $imageUrl = $this->getImageUrl($productModel, $imageSize);
+            } else {
+                $upperCaseImage = $this->getImageFunctionName($imageSize);
+                $imageUrl = $productModel->$upperCaseImage();
+            }
             $this->setCurrentStore($curStore);
         }
         return $imageUrl;
+    }
+
+    public function getImageUrl($productModel, $imageSize)
+    {
+        return (string)$this->_getImageHelper()->init($productModel, $imageSize);
     }
 
     /**

--- a/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
@@ -1316,6 +1316,9 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
             case 2:
                 $imageSize = Ebizmarts_MailChimp_Model_Config::IMAGE_SIZE_THUMBNAIL;
                 break;
+            case 3:
+                $imageSize = Ebizmarts_MailChimp_Model_Config::IMAGE_SIZE_DEFAULT;
+                break;
             default:
                 $imageSize = Ebizmarts_MailChimp_Model_Config::IMAGE_SIZE_DEFAULT;
                 break;

--- a/app/code/community/Ebizmarts/MailChimp/Model/System/Config/Source/ImageSize.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/System/Config/Source/ImageSize.php
@@ -12,6 +12,7 @@ class Ebizmarts_MailChimp_Model_System_Config_Source_ImageSize
     const BASE = 0;
     const SMALL = 1;
     const THUMBNAIL = 2;
+    const ORIGINAL = 3;
 
 
     /**
@@ -25,8 +26,8 @@ class Ebizmarts_MailChimp_Model_System_Config_Source_ImageSize
         return array(
             array('value' => self::BASE, 'label' => $helper->__('Base')),
             array('value' => self::SMALL, 'label' => $helper->__('Small')),
-            array('value' => self::THUMBNAIL, 'label' => $helper->__('Thumbnail'))
-
+            array('value' => self::THUMBNAIL, 'label' => $helper->__('Thumbnail')),
+            array('value' => self::ORIGINAL, 'label' => $helper->__('Original'))
         );
     }
 }


### PR DESCRIPTION
- Add option to send original unresized product images to Mailchimp in the admin panel configuration
- Adapt unit test to include new use case