### PR TITLE
Subscription fails when one store view is disabled with the API key in blank

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
@@ -3294,38 +3294,42 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function getInterestGroups($customerId, $subscriberId, $storeId, $interest = null)
     {
-        if (!$interest) {
-            $interest = $this->getInterest($storeId);
-        }
-        $interestGroup = $this->getInterestGroupModel();
-        $interestGroup->getByRelatedIdStoreId($customerId, $subscriberId, $storeId);
-        if ($interestGroup->getId()) {
-            $groups = $this->arrayDecode($interestGroup->getGroupdata());
-            foreach ($groups as $key => $value) {
-                if (isset($interest[$key])) {
-                    if (is_array($value)) {
-                        foreach ($value as $groupId) {
-                            foreach ($interest[$key]['category'] as $gkey => $gvalue) {
-                                if ($gvalue['id'] == $groupId) {
-                                    $interest[$key]['category'][$gkey]['checked'] = true;
-                                } elseif (!isset($interest[$key]['category'][$gkey]['checked'])) {
-                                    $interest[$key]['category'][$gkey]['checked'] = false;
+        if ($this->isSubscriptionEnabled($storeId)) {
+            if (!$interest) {
+                $interest = $this->getInterest($storeId);
+            }
+            $interestGroup = $this->getInterestGroupModel();
+            $interestGroup->getByRelatedIdStoreId($customerId, $subscriberId, $storeId);
+            if ($interestGroup->getId()) {
+                $groups = $this->arrayDecode($interestGroup->getGroupdata());
+                foreach ($groups as $key => $value) {
+                    if (isset($interest[$key])) {
+                        if (is_array($value)) {
+                            foreach ($value as $groupId) {
+                                foreach ($interest[$key]['category'] as $gkey => $gvalue) {
+                                    if ($gvalue['id'] == $groupId) {
+                                        $interest[$key]['category'][$gkey]['checked'] = true;
+                                    } elseif (!isset($interest[$key]['category'][$gkey]['checked'])) {
+                                        $interest[$key]['category'][$gkey]['checked'] = false;
+                                    }
                                 }
                             }
-                        }
-                    } else {
-                        foreach ($interest[$key]['category'] as $gkey => $gvalue) {
-                            if ($gvalue['id'] == $value) {
-                                $interest[$key]['category'][$gkey]['checked'] = true;
-                            } else {
-                                $interest[$key]['category'][$gkey]['checked'] = false;
+                        } else {
+                            foreach ($interest[$key]['category'] as $gkey => $gvalue) {
+                                if ($gvalue['id'] == $value) {
+                                    $interest[$key]['category'][$gkey]['checked'] = true;
+                                } else {
+                                    $interest[$key]['category'][$gkey]['checked'] = false;
+                                }
                             }
                         }
                     }
                 }
             }
+            return $interest;
+        } else {
+            return array();
         }
-        return $interest;
     }
 
 

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Helper/DataTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Helper/DataTest.php
@@ -1263,7 +1263,7 @@ class Ebizmarts_MailChimp_Helper_DataTest extends PHPUnit_Framework_TestCase
 
         $helperMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getInterest', 'getInterestGroupModel', 'getLocalInterestCategories', 'arrayDecode'))
+            ->setMethods(array('getInterest', 'getInterestGroupModel', 'getLocalInterestCategories', 'arrayDecode', 'isSubscriptionEnabled'))
             ->getMock();
 
         $interestGroupMock = $this->getMockBuilder(Ebizmarts_MailChimp_Model_Interestgroup::class)
@@ -1271,6 +1271,7 @@ class Ebizmarts_MailChimp_Helper_DataTest extends PHPUnit_Framework_TestCase
             ->setMethods(array('getByRelatedIdStoreId', 'getId', 'getGroupdata'))
             ->getMock();
 
+        $helperMock->expects($this->once())->method('isSubscriptionEnabled')->with($storeId)->willReturn(true);
         $helperMock->expects($this->once())->method('getInterest')->with($storeId)->willReturn($interest);
         $helperMock->expects($this->once())->method('getInterestGroupModel')->willReturn($interestGroupMock);
 
@@ -1279,6 +1280,25 @@ class Ebizmarts_MailChimp_Helper_DataTest extends PHPUnit_Framework_TestCase
         $interestGroupMock->expects($this->once())->method('getGroupdata')->willReturn($encodedGroupData);
 
         $helperMock->expects($this->once())->method('arrayDecode')->with($encodedGroupData)->willReturn($groupData);
+
+        $result = $helperMock->getInterestGroups($customerId, $subscriberId, $storeId);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testGetInterestGroupsIsSubscriptionDisabled ()
+    {
+        $customerId = 1;
+        $subscriberId = 1;
+        $storeId = 1;
+        $expectedResult = array();
+
+        $helperMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('isSubscriptionEnabled'))
+            ->getMock();
+
+        $helperMock->expects($this->once())->method('isSubscriptionEnabled')->with($storeId)->willReturn(false);
 
         $result = $helperMock->getInterestGroups($customerId, $subscriberId, $storeId);
 


### PR DESCRIPTION
- The program fails when a registered user subscribe to the newsletter at 'My account->Newsletter' or after place the order.
- Check if the module is enabled before execute the code in the function **getInterestGroups** if the module is disabled the function returns an empty array.
- Modified **testGetInterestGroups** to adapt it to the change in the function **getInterestGroups**