### PR TITLE
closes #871 added acl permissions to the action createWebhook

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/controllers/Adminhtml/MailchimpController.php
+++ b/app/code/community/Ebizmarts/MailChimp/controllers/Adminhtml/MailchimpController.php
@@ -62,11 +62,11 @@ class Ebizmarts_MailChimp_Adminhtml_MailchimpController extends Mage_Adminhtml_C
     {
         $acl = null;
         switch ($this->getRequest()->getActionName()) {
-        case 'index':
-        case 'resendSubscribers':
-        case 'createWebhook':
-            $acl = 'system/config/mailchimp';
-            break;
+            case 'index':
+            case 'resendSubscribers':
+            case 'createWebhook':
+                $acl = 'system/config/mailchimp';
+                break;
         }
 
         return Mage::getSingleton('admin/session')->isAllowed($acl);

--- a/app/code/community/Ebizmarts/MailChimp/controllers/Adminhtml/MailchimpController.php
+++ b/app/code/community/Ebizmarts/MailChimp/controllers/Adminhtml/MailchimpController.php
@@ -66,6 +66,9 @@ class Ebizmarts_MailChimp_Adminhtml_MailchimpController extends Mage_Adminhtml_C
         case 'resendSubscribers':
             $acl = 'system/config/mailchimp';
             break;
+        case 'createWebhook':
+            $acl = 'system/config/mailchimp';
+            break;
         }
 
         return Mage::getSingleton('admin/session')->isAllowed($acl);

--- a/app/code/community/Ebizmarts/MailChimp/controllers/Adminhtml/MailchimpController.php
+++ b/app/code/community/Ebizmarts/MailChimp/controllers/Adminhtml/MailchimpController.php
@@ -64,8 +64,6 @@ class Ebizmarts_MailChimp_Adminhtml_MailchimpController extends Mage_Adminhtml_C
         switch ($this->getRequest()->getActionName()) {
         case 'index':
         case 'resendSubscribers':
-            $acl = 'system/config/mailchimp';
-            break;
         case 'createWebhook':
             $acl = 'system/config/mailchimp';
             break;


### PR DESCRIPTION
Modified the function _isAllowed() added the case of the action createWebhook in the file MailchimpController.php for Magento custom users without Admin permissions. 