### PR TITLE
Multiple confirmation email from mailchimp after group subscription

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
@@ -280,6 +280,16 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
     }
 
     /**
+     *
+     * @param $scopeId
+     * @return bool | returns true if useMagentoEmails is enabled
+     */
+    public function isUseMagentoEmailsEnabled ($scopeId)
+    {
+        return $this->getConfigValueForScope(Ebizmarts_MailChimp_Model_Config::GENERAL_MAGENTO_MAIL, $scopeId);
+    }
+
+    /**
      * Return if module is enabled and list selected for given scope.
      *
      * @param  $scopeId

--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -147,7 +147,7 @@ class Ebizmarts_MailChimp_Model_Observer
                 $subscriber->setStatus(Mage_Newsletter_Model_Subscriber::STATUS_NOT_ACTIVE);
                 $this->addSuccessIfRequired($helper);
             }
-//            $subscriber->setImportMode(true);
+
         }
 
         return $observer;
@@ -175,7 +175,6 @@ class Ebizmarts_MailChimp_Model_Observer
             $this->createEmailCookie($subscriber);
 
             if ($helper->isUseMagentoEmailsEnabled($storeId) != 1) {
-                Mage::log('estoy en subscriberSaveAfter', null, 'ebizmartsSubscriberSaveAfter.log', true);
                 $apiSubscriber = $this->makeApiSubscriber();
                 if ($subscriber->getIsStatusChanged()) {
                     $apiSubscriber->updateSubscriber($subscriber, true);
@@ -293,7 +292,6 @@ class Ebizmarts_MailChimp_Model_Observer
             }
             //update subscriber data if a subscriber with the same email address exists and was not affected.
             if (!$origEmail || $origEmail == $customerEmail) {
-                Mage::log('estoy en customerSaveAfter', null, 'ebizmartsCustomerSaveAfter.log', true);
                 $apiSubscriber->update($customerEmail, $storeId);
             }
 

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
@@ -673,7 +673,6 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
     public function testSubscriberSaveBefore($data)
     {
         $getStoreId = $data['getStoreId'];
-        $magentoMail = $data['magentoMail'];
         $subscriberUpdatedAmount = $data['subscriberUpdatedAmount'];
         $storeId = 1;
 
@@ -684,13 +683,13 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $observerMock = $this->getMockBuilder(Ebizmarts_MailChimp_Model_Observer::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('makeHelper', 'addSuccessIfRequired', 'makeApiSubscriber'))
+            ->setMethods(array('makeHelper', 'addSuccessIfRequired'))
             ->getMock();
 
         $helperMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
             ->disableOriginalConstructor()
             ->setMethods(array('isSubscriptionEnabled', 'isEcomSyncDataEnabledInAnyScope',
-                'isSubscriptionConfirmationEnabled', 'getConfigValueForScope', 'getStoreId'))
+                'isSubscriptionConfirmationEnabled', 'getStoreId'))
             ->getMock();
 
         $eventMock = $this->getMockBuilder(Varien_Event::class)
@@ -703,11 +702,6 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
             ->setMethods(array('getSubscriberSource', 'getIsStatusChanged', 'getStatus', 'setStatus', 'getStoreId'))
             ->getMock();
 
-        $apiSubscriberMock = $this->getMockBuilder(Ebizmarts_MailChimp_Model_Api_Subscribers::class)
-            ->disableOriginalConstructor()
-            ->setMethods(array('updateSubscriber'))
-            ->getMock();
-
         $eventObserverMock->expects($this->once())->method('getEvent')->willReturn($eventMock);
 
         $eventMock->expects($this->once())->method('getSubscriber')->willReturn($subscriberMock);
@@ -718,21 +712,15 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $helperMock->expects($this->once())->method('isSubscriptionEnabled')->with($storeId)->willReturn(true);
 
-        $subscriberMock->expects($this->once())->method('getIsStatusChanged')->willReturn(true);
-
-        $observerMock->expects($this->once())->method('makeApiSubscriber')->willReturn($apiSubscriberMock);
-
         $subscriberMock->expects($this->once())->method('getStatus')->willReturn(Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED);
+
+        $subscriberMock->expects($this->once())->method('getIsStatusChanged')->willReturn(true);
 
         $helperMock->expects($this->once())->method('isSubscriptionConfirmationEnabled')->with($storeId)->willReturn(true);
 
         $subscriberMock->expects($this->once())->method('setStatus')->with(Mage_Newsletter_Model_Subscriber::STATUS_NOT_ACTIVE);
 
         $observerMock->expects($this->once())->method('addSuccessIfRequired')->with($helperMock);
-
-        $helperMock->expects($this->once())->method('getConfigValueForScope')->with(Ebizmarts_MailChimp_Model_Config::GENERAL_MAGENTO_MAIL, $storeId)->willReturn($magentoMail);
-
-        $apiSubscriberMock->expects($this->exactly($subscriberUpdatedAmount))->method('updateSubscriber')->with($subscriberMock, true);
 
         $subscriberMock->expects($this->once())->method('getSubscriberSource')->willReturn(null);
 
@@ -754,7 +742,6 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
     {
         $storeId = 1;
         $params = array();
-        $magentoMail = 0;
 
         $eventObserverMock = $this->getMockBuilder(Varien_Event_Observer::class)
             ->disableOriginalConstructor()
@@ -768,7 +755,7 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $helperMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('isSubscriptionEnabled', 'saveInterestGroupData', 'getConfigValueForScope'))
+            ->setMethods(array('isSubscriptionEnabled', 'saveInterestGroupData', 'isUseMagentoEmailsEnabled'))
             ->getMock();
 
         $eventMock = $this->getMockBuilder(Varien_Event::class)
@@ -778,7 +765,7 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $subscriberMock = $this->getMockBuilder(Mage_Newsletter_Model_Subscriber::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getSubscriberSource', 'getStoreId'))
+            ->setMethods(array('getSubscriberSource', 'getStoreId', 'getIsStatusChanged'))
             ->getMock();
 
         $requestMock = $this->getMockBuilder(Mage_Core_Controller_Request_Http::class)
@@ -811,7 +798,9 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $observerMock->expects($this->once())->method('createEmailCookie')->with($subscriberMock);
 
-        $helperMock->expects($this->once())->method('getConfigValueForScope')->with(Ebizmarts_MailChimp_Model_Config::GENERAL_MAGENTO_MAIL, $storeId)->willReturn($magentoMail);
+        $helperMock->expects($this->once())->method('isUseMagentoEmailsEnabled')->with($storeId)->willReturn(false);
+
+        $subscriberMock->expects($this->once())->method('getIsStatusChanged')->willReturn(true);
 
         $observerMock->expects($this->once())->method('makeApiSubscriber')->willReturn($apiSubscriberMock);
 


### PR DESCRIPTION
Modified the functions subscriberSaveAfter and subscriberSaveBefore removed repeated code which caused send double email confirmation subscription.