### PR TITLE
Mandrill default scope disabled enabled on specific website/storeview breaks order comment emails

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Email/Template.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Email/Template.php
@@ -188,7 +188,7 @@ class Ebizmarts_MailChimp_Model_Email_Template extends Ebizmarts_MailChimp_Model
             return parent::getMail();
         }
 
-        if ($this->_mail && (!Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE, $storeId))) {
+        if ($this->_mail && (!$this->isMandrillEnabled($storeId))) {
             return $this->_mail;
         } else {
             Mage::helper('mailchimp/mandrill')->log("store: $storeId API: " . Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_APIKEY, $storeId), $storeId);

--- a/app/code/community/Ebizmarts/MailChimp/Model/Email/Template.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Email/Template.php
@@ -182,15 +182,15 @@ class Ebizmarts_MailChimp_Model_Email_Template extends Ebizmarts_MailChimp_Model
      */
     public function getMail()
     {
-        $storeId = Mage::app()->getStore()->getId();
+        $email_config = $this->getDesignConfig();
+        $storeId = (integer) $email_config->getStore();
         if (!Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE, $storeId)) {
             return parent::getMail();
         }
 
-        if ($this->_mail) {
+        if ($this->_mail && (!Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE, $storeId))) {
             return $this->_mail;
         } else {
-            $storeId = Mage::app()->getStore()->getId();
             Mage::helper('mailchimp/mandrill')->log("store: $storeId API: " . Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_APIKEY, $storeId), $storeId);
             $this->_mail = new Mandrill_Message(Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_APIKEY, $storeId));
             return $this->_mail;

--- a/app/code/community/Ebizmarts/MailChimp/Model/Email/Template.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Email/Template.php
@@ -188,12 +188,11 @@ class Ebizmarts_MailChimp_Model_Email_Template extends Ebizmarts_MailChimp_Model
             return parent::getMail();
         }
 
-        if ($this->_mail && (!$this->isMandrillEnabled($storeId))) {
+        if ($this->_mail && (!Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE, $storeId))) {
             return $this->_mail;
         } else {
             Mage::helper('mailchimp/mandrill')->log("store: $storeId API: " . Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_APIKEY, $storeId), $storeId);
-            $this->_mail = new Mandrill_Message(Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_APIKEY, $storeId));
-            return $this->_mail;
+            return $this->createMandrillMessage($storeId);
         }
     }
 
@@ -278,5 +277,15 @@ class Ebizmarts_MailChimp_Model_Email_Template extends Ebizmarts_MailChimp_Model
     protected function isMandrillEnabled($storeId)
     {
         return Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return Mandrill_Message
+     * @throws Mandrill_Error
+     */
+    protected function createMandrillMessage($storeId)
+    {
+        return $this->_mail = new Mandrill_Message(Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_APIKEY, $storeId));
     }
 }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Email/Template.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Email/Template.php
@@ -184,11 +184,11 @@ class Ebizmarts_MailChimp_Model_Email_Template extends Ebizmarts_MailChimp_Model
     {
         $email_config = $this->getDesignConfig();
         $storeId = (integer) $email_config->getStore();
-        if (!Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE, $storeId)) {
+        if (!$this->isMandrillEnabled($storeId)) {
             return parent::getMail();
         }
 
-        if ($this->_mail && (!Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE, $storeId))) {
+        if ($this->_mail && (!$this->isMandrillEnabled($storeId))) {
             return $this->_mail;
         } else {
             Mage::helper('mailchimp/mandrill')->log("store: $storeId API: " . Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_APIKEY, $storeId), $storeId);
@@ -269,5 +269,14 @@ class Ebizmarts_MailChimp_Model_Email_Template extends Ebizmarts_MailChimp_Model
     protected function getGeneralEmail()
     {
         return Mage::getStoreConfig('trans_email/ident_general/email');
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    protected function isMandrillEnabled($storeId)
+    {
+        return Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::MANDRILL_ACTIVE, $storeId);
     }
 }

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Email/TemplateTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Email/TemplateTest.php
@@ -81,4 +81,51 @@ class Ebizmarts_MailChimp_Model_TemplateTest extends PHPUnit_Framework_TestCase
 
         $templateMock->send($email, $name, $variables);
     }
+
+    public function testGetMailCreateNewMandrillEmail()
+    {
+        $storeId = 1;
+
+        $templateMock = $this->getMockBuilder(Ebizmarts_MailChimp_Model_Email_Template::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getDesignConfig', 'isMandrillEnabled'))
+            ->getMock();
+
+        $varienObjectMock = $this->getMockBuilder(Varien_Object::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getStore'))
+            ->getMock();
+
+        $templateMock->expects($this->once())->method('getDesignConfig')->willReturn($varienObjectMock);
+        $templateMock->expects($this->once())->method('isMandrillEnabled')->with($storeId)->willReturnOnConsecutiveCalls(
+            true,
+            true
+        );
+
+        $varienObjectMock->expects($this->once())->method('getStore')->willReturn($storeId);
+
+        $templateMock->getMail();
+    }
+
+    public function testGetMailMandrillEmailDisabled()
+    {
+        $storeId = 1;
+
+        $templateMock = $this->getMockBuilder(Ebizmarts_MailChimp_Model_Email_Template::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getDesignConfig', 'isMandrillEnabled'))
+            ->getMock();
+
+        $varienObjectMock = $this->getMockBuilder(Varien_Object::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getStore'))
+            ->getMock();
+
+        $templateMock->expects($this->once())->method('getDesignConfig')->willReturn($varienObjectMock);
+        $templateMock->expects($this->once())->method('isMandrillEnabled')->with($storeId)->willReturn(false);
+
+        $varienObjectMock->expects($this->once())->method('getStore')->willReturn($storeId);
+
+        $templateMock->getMail();
+    }
 }

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Email/TemplateTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Email/TemplateTest.php
@@ -88,7 +88,7 @@ class Ebizmarts_MailChimp_Model_TemplateTest extends PHPUnit_Framework_TestCase
 
         $templateMock = $this->getMockBuilder(Ebizmarts_MailChimp_Model_Email_Template::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getDesignConfig', 'isMandrillEnabled'))
+            ->setMethods(array('getDesignConfig', 'isMandrillEnabled', 'createMandrillMessage'))
             ->getMock();
 
         $varienObjectMock = $this->getMockBuilder(Varien_Object::class)
@@ -97,6 +97,7 @@ class Ebizmarts_MailChimp_Model_TemplateTest extends PHPUnit_Framework_TestCase
             ->getMock();
 
         $templateMock->expects($this->once())->method('getDesignConfig')->willReturn($varienObjectMock);
+        $templateMock->expects($this->once())->method('createMandrillMessage')->with($storeId);
         $templateMock->expects($this->once())->method('isMandrillEnabled')->with($storeId)->willReturnOnConsecutiveCalls(
             true,
             true


### PR DESCRIPTION
- Modified the function getMail to get the storeId from another way.
- Implemented the test getMail
- Modified the function getMail to adapt it to the test