### PR TITLE
Fix typo in block name due to 'Invalid block type: Ebizmarts_MailChimp_Block_Group_Types' error.

### DIFF
--- a/app/design/frontend/base/default/layout/ebizmarts/mailchimp.xml
+++ b/app/design/frontend/base/default/layout/ebizmarts/mailchimp.xml
@@ -40,7 +40,7 @@
             <block name="customer.form.newsletter.extra"
                    type="mailchimp/customer_newsletter_index"
                    template="ebizmarts/mailchimp/customer/newsletter/index.phtml">
-                <block type="mailchimp/group_types" name="mailchimp.group.types" template="ebizmarts/mailchimp/group/types.phtml"/>
+                <block type="mailchimp/group_type" name="mailchimp.group.types" template="ebizmarts/mailchimp/group/types.phtml"/>
             </block>
         </reference>
     </newsletter_manage_index>
@@ -57,7 +57,7 @@
         <reference name="content">
             <block type="mailchimp/checkout_success_groups" name="mailchimp.checkout.success"
                    template="ebizmarts/mailchimp/checkout/success/groups.phtml">
-                <block type="mailchimp/group_types" name="mailchimp.group.types" template="ebizmarts/mailchimp/group/types.phtml"/>
+                <block type="mailchimp/group_type" name="mailchimp.group.types" template="ebizmarts/mailchimp/group/types.phtml"/>
             </block>
         </reference>
     </checkout_onepage_success>


### PR DESCRIPTION
I found this in error log:

```
==> /var/log/exception.log <==
2019-02-22T01:30:00+00:00 ERR (3):
exception 'Mage_Core_Exception' with message 'Invalid block type: Ebizmarts_MailChimp_Block_Group_Types' in /app/Mage.php:598
Stack trace:
#0 /app/code/core/Mage/Core/Model/Layout.php(495): Mage::throwException('Invalid block t...')
#1 /app/code/core/Mage/Core/Model/Layout.php(437): Mage_Core_Model_Layout->_getBlockInstance('mailchimp/group...', Array)
#2 /app/code/core/Mage/Core/Model/Layout.php(472): Mage_Core_Model_Layout->createBlock('mailchimp/group...', 'mailchimp.group...')
#3 /app/code/core/Mage/Core/Model/Layout.php(239): Mage_Core_Model_Layout->addBlock('mailchimp/group...', 'mailchimp.group...')
#4 /app/code/core/Mage/Core/Model/Layout.php(205): Mage_Core_Model_Layout->_generateBlock(Object(Mage_Core_Model_Layout_Element), Object(Mage_Core_Model_Layout_Element))
#5 /app/code/core/Mage/Core/Model/Layout.php(206): Mage_Core_Model_Layout->generateBlocks(Object(Mage_Core_Model_Layout_Element))
#6 /app/code/core/Mage/Core/Model/Layout.php(210): Mage_Core_Model_Layout->generateBlocks(Object(Mage_Core_Model_Layout_Element))
#7 /app/code/core/Mage/Core/Controller/Varien/Action.php(344): Mage_Core_Model_Layout->generateBlocks()
#8 /app/code/core/Mage/Core/Controller/Varien/Action.php(269): Mage_Core_Controller_Varien_Action->generateLayoutBlocks()
#9 /app/code/core/Mage/Checkout/controllers/OnepageController.php(295): Mage_Core_Controller_Varien_Action->loadLayout()
#10 /app/code/local/Acidgreen/Checkout/controllers/OnepageController.php(11): Mage_Checkout_OnepageController->successAction()
#11 /app/code/core/Mage/Core/Controller/Varien/Action.php(418): Acidgreen_Checkout_OnepageController->successAction()
#12 /app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(254): Mage_Core_Controller_Varien_Action->dispatch('success')
#13 /app/code/local/Mage/Core/Controller/Varien/Front.php(172): Mage_Core_Controller_Varien_Router_Standard->match(Object(Mage_Core_Controller_Request_Http))
#14 /app/code/core/Mage/Core/Model/App.php(365): Mage_Core_Controller_Varien_Front->dispatch()
#15 /app/Mage.php(687): Mage_Core_Model_App->run(Array)
#16 /index.php(86): Mage::run('', 'store')
#17 {main}
```

It should be `Ebizmarts_MailChimp_Block_Group_Type` not `Ebizmarts_MailChimp_Block_Group_Types`

see file - app/design/frontend/base/default/layout/ebizmarts/mailchimp.xml line (43 & 60)

change `<block type="mailchimp/group_types"` to `<block type="mailchimp/group_type"`