### PR TITLE
Avoid get by email calls when sending orders and carts to mailchimp

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Carts.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Carts.php
@@ -169,7 +169,7 @@ class Ebizmarts_MailChimp_Model_Api_Carts
             // send the products that not already sent
             $allCarts = $this->addProductNotSentData($mailchimpStoreId, $magentoStoreId, $cart, $allCarts);
 
-            $cartJson = $this->_makeCart($cart, $mailchimpStoreId, $magentoStoreId, true);
+            $cartJson = $this->_makeCart($cart, $magentoStoreId, true);
             if ($cartJson != "") {
                 $counter = $this->getCounter();
                 $allCarts[$counter]['method'] = 'PATCH';
@@ -255,7 +255,7 @@ class Ebizmarts_MailChimp_Model_Api_Carts
             // send the products that not already sent
             $allCarts = $this->addProductNotSentData($mailchimpStoreId, $magentoStoreId, $cart, $allCarts);
 
-            $cartJson = $this->_makeCart($cart, $mailchimpStoreId, $magentoStoreId);
+            $cartJson = $this->_makeCart($cart, $magentoStoreId);
             if ($cartJson != "") {
                 $counter = $this->getCounter();
                 $allCarts[$counter]['method'] = 'POST';
@@ -302,12 +302,11 @@ class Ebizmarts_MailChimp_Model_Api_Carts
 
     /**
      * @param $cart
-     * @param $mailchimpStoreId
      * @param $magentoStoreId
      * @param $isModified
      * @return string
      */
-    protected function _makeCart($cart, $mailchimpStoreId, $magentoStoreId, $isModified = false)
+    public function _makeCart($cart, $magentoStoreId, $isModified = false)
     {
         $helper = $this->getHelper();
         $campaignId = $cart->getMailchimpCampaignId();
@@ -336,7 +335,7 @@ class Ebizmarts_MailChimp_Model_Api_Carts
                 continue;
             }
 
-            if ($item->getProductType() == Mage_Catalog_Model_Product_Type::TYPE_CONFIGURABLE) {
+            if ($this->isProductTypeConfigurable($item)) {
                 $variant = null;
                 if ($item->getOptionByCode('simple_product')) {
                     $variant = $item->getOptionByCode('simple_product')->getProduct();
@@ -652,6 +651,15 @@ class Ebizmarts_MailChimp_Model_Api_Carts
     protected function getCountryModel($billingAddress)
     {
         return Mage::getModel('directory/country')->loadByCode($billingAddress->getCountry())->getName();
+    }
+
+    /**
+     * @param $item
+     * @return bool
+     */
+    protected function isProductTypeConfigurable($item)
+    {
+        return $item->getProductType() == Mage_Catalog_Model_Product_Type::TYPE_CONFIGURABLE;
     }
 }
 

--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Customers.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Customers.php
@@ -92,7 +92,7 @@ class Ebizmarts_MailChimp_Model_Api_Customers
     protected function _buildCustomerData($customer)
     {
         $data = array();
-        $data["id"] = $customer->getId();
+        $data["id"] = md5($this->getCustomerEmail($customer));
         $data["email_address"] = $this->getCustomerEmail($customer);
         $data["first_name"] = $this->getCustomerFirstname($customer);
         $data["last_name"] = $this->getCustomerLastname($customer);
@@ -175,19 +175,6 @@ class Ebizmarts_MailChimp_Model_Api_Customers
     {
         $mailchimpStoreId = $this->mailchimpHelper->getMCStoreId($storeId);
         $this->_updateSyncData($customerId, $mailchimpStoreId, null, null, 1, null, true, false);
-    }
-
-    public function createGuestCustomer($guestId, $order)
-    {
-        $guestCustomer = Mage::getModel('customer/customer')->setId($guestId);
-        foreach ($order->getData() as $key => $value) {
-            $keyArray = explode('_', $key);
-            if ($value && isset($keyArray[0]) && $keyArray[0] == 'customer') {
-                $guestCustomer->{'set' . ucfirst($keyArray[1])}($value);
-            }
-        }
-
-        return $guestCustomer;
     }
 
     public function getOptin($magentoStoreId)

--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Orders.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Orders.php
@@ -58,7 +58,7 @@ class Ebizmarts_MailChimp_Model_Api_Orders
         $helper = $this->getHelper();
         $mailchimpTableName = Mage::getSingleton('core/resource')->getTableName('mailchimp/ecommercesyncdata');
         $batchArray = array();
-        $modifiedOrders = Mage::getResourceModel('sales/order_collection');
+        $modifiedOrders = $this->getResourceModelOrderCollection();
         // select orders for the current Magento store id
         $modifiedOrders->addFieldToFilter('store_id', array('eq' => $magentoStoreId));
         //join with mailchimp_ecommerce_sync_data table to filter by sync data.
@@ -107,7 +107,7 @@ class Ebizmarts_MailChimp_Model_Api_Orders
     {
         $helper = $this->getHelper();
         $batchArray = array();
-        $newOrders = Mage::getResourceModel('sales/order_collection');
+        $newOrders = $this->getResourceModelOrderCollection();
         // select carts for the current Magento store id
         $newOrders->addFieldToFilter('store_id', array('eq' => $magentoStoreId));
         $helper->addResendFilter($newOrders, $magentoStoreId, Ebizmarts_MailChimp_Model_Config::IS_ORDER);
@@ -355,7 +355,7 @@ class Ebizmarts_MailChimp_Model_Api_Orders
         }
 
         //customer orders data
-        $orderCollection = Mage::getResourceModel('sales/order_collection')
+        $orderCollection = $this->getResourceModelOrderCollection()
             ->addFieldToFilter(
                 'state',
                 array(
@@ -513,7 +513,7 @@ class Ebizmarts_MailChimp_Model_Api_Orders
         $mailchimpTableName = Mage::getSingleton('core/resource')->getTableName('mailchimp/ecommercesyncdata');
         $batchArray = array();
         $config = array();
-        $orderCollection = Mage::getResourceModel('sales/order_collection');
+        $orderCollection = $this->getResourceModelOrderCollection();
         // select carts for the current Magento store id
         $orderCollection->addFieldToFilter('store_id', array('eq' => $magentoStoreId));
         if ($lastId) {
@@ -755,5 +755,13 @@ class Ebizmarts_MailChimp_Model_Api_Orders
     protected function getCountryModelNameFromShippingAddress($shippingAddress)
     {
         return Mage::getModel('directory/country')->loadByCode($shippingAddress->getCountry())->getName();
+    }
+
+    /**
+     * @return Mage_Sales_Model_Resource_Order_Collection
+     */
+    protected function getResourceModelOrderCollection()
+    {
+        return Mage::getResourceModel('sales/order_collection');
     }
 }

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/CartsTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/CartsTest.php
@@ -1705,16 +1705,26 @@ class Ebizmarts_MailChimp_Model_Api_CartsTest extends PHPUnit_Framework_TestCase
         $productQty = 1;
         $productPrice = 210;
         $variantId = 12;
+        $firstName = 'test';
+        $lastName = 'test';
+        $street = array(
+            'address1' => 'test',
+            'address2' => 'test'
+        );
+        $city = 'test';
+        $region = 'test';
+        $optinStatus = false;
+        $company = 'test';
+        $regionCode = 'test';
+        $postCode = 'test';
+        $country = 'test';
 
         $cartsApiMock = $this->cartsApiMock->setMethods(array(
-            '_getCustomer',
             '_getCheckoutUrl',
-            'isProductTypeConfigurable'
+            'isProductTypeConfigurable',
+            'getApiCustomersOptIn',
+            'getCountryModel'
         ))
-            ->getMock();
-
-        $customerModelMock = $this->getMockBuilder(Ebizmarts_MailChimp_Model_Api_Customers::class)
-            ->setMethods(array())
             ->getMock();
 
         $cartModelMock = $this
@@ -1725,7 +1735,10 @@ class Ebizmarts_MailChimp_Model_Api_CartsTest extends PHPUnit_Framework_TestCase
                 'getEntityId',
                 'getQuoteCurrencyCode',
                 'getGrandTotal',
-                'getAllVisibleItems'
+                'getAllVisibleItems',
+                'getCustomerFirstname',
+                'getCustomerLastname',
+                'getBillingAddress'
             ))
             ->getMock();
 
@@ -1749,10 +1762,19 @@ class Ebizmarts_MailChimp_Model_Api_CartsTest extends PHPUnit_Framework_TestCase
             ->setMethods(array('getId'))
             ->getMock();
 
+        $billingAddressMock = $this
+            ->getMockBuilder(Mage_Sales_Model_Order_Address::class)
+            ->setMethods(array('getStreet', 'getCity', 'getRegion', 'getRegionCode', 'getPostcode', 'getCountry', 'getCompany'))
+            ->getMock();
+
         $cartsApiMock->expects($this->once())
-            ->method('_getCustomer')
-            ->with($cartModelMock, self::MAGENTO_STORE_ID)
-            ->willReturn($customerModelMock);
+            ->method('getApiCustomersOptIn')
+            ->with(self::MAGENTO_STORE_ID)
+            ->willReturn($optinStatus);
+        $cartsApiMock->expects($this->once())
+            ->method('getCountryModel')
+            ->with($billingAddressMock)
+            ->willReturn($country);
         $cartsApiMock->expects($this->once())
             ->method('_getCheckoutUrl')
             ->with($cartModelMock, $isModified)
@@ -1762,6 +1784,15 @@ class Ebizmarts_MailChimp_Model_Api_CartsTest extends PHPUnit_Framework_TestCase
             ->with($itemMock)
             ->willReturn(true);
 
+        $cartModelMock->expects($this->once())
+            ->method('getCustomerFirstname')
+            ->willReturn($firstName);
+        $cartModelMock->expects($this->once())
+            ->method('getCustomerLastname')
+            ->willReturn($lastName);
+        $cartModelMock->expects($this->once())
+            ->method('getBillingAddress')
+            ->willReturn($billingAddressMock);
         $cartModelMock->expects($this->once())
             ->method('getMailchimpCampaignId')
             ->willReturn($mailchimpCampaignId);
@@ -1814,6 +1845,46 @@ class Ebizmarts_MailChimp_Model_Api_CartsTest extends PHPUnit_Framework_TestCase
         $variantMock->expects($this->once())
             ->method('getId')
             ->willReturn($variantId);
+
+        $billingAddressMock->expects($this->once())
+            ->method('getStreet')
+            ->willReturn($street);
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getCity')
+            ->willReturnOnConsecutiveCalls(
+                $city,
+                $city
+            );
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getRegion')
+            ->willReturnOnConsecutiveCalls(
+                $region,
+                $region
+            );
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getRegionCode')
+            ->willReturnOnConsecutiveCalls(
+                $regionCode,
+                $regionCode
+            );
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getPostcode')
+            ->willReturnOnConsecutiveCalls(
+                $postCode,
+                $postCode
+            );
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getCountry')
+            ->willReturnOnConsecutiveCalls(
+                $country,
+                $country
+            );
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getCompany')
+            ->willReturnOnConsecutiveCalls(
+                $company,
+                $company
+            );
 
         $cartsApiMock->_makeCart($cartModelMock, self::MAGENTO_STORE_ID, $isModified);
     }

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/CartsTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/CartsTest.php
@@ -1599,4 +1599,96 @@ class Ebizmarts_MailChimp_Model_Api_CartsTest extends PHPUnit_Framework_TestCase
 
         $cartsApiMock->getAllCartsByEmail(self::CUSTOMER_EMAIL_BY_CART, self::MAILCHIMP_STORE_ID, self::MAGENTO_STORE_ID);
     }
+
+    public function testGetCustomer()
+    {
+        $firstName = 'test';
+        $lastName = 'test';
+        $street = array(
+            'address1' => 'test',
+            'address2' => 'test'
+        );
+        $city = 'test';
+        $region = 'test';
+        $optinStatus = false;
+        $company = 'test';
+        $regionCode = 'test';
+        $postCode = 'test';
+        $country = 'test';
+        $cartsApiMock = $this->cartsApiMock
+            ->setMethods(array('getApiCustomersOptIn', 'getCountryModel'))
+            ->getMock();
+
+        $cartModelMock = $this
+            ->getMockBuilder(Mage_Sales_Model_Quote::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getCustomerFirstname', 'getCustomerLastname', 'getBillingAddress'))
+            ->getMock();
+
+        $billingAddressMock = $this
+            ->getMockBuilder(Mage_Sales_Model_Order_Address::class)
+            ->setMethods(array('getStreet', 'getCity', 'getRegion', 'getRegionCode', 'getPostcode', 'getCountry', 'getCompany'))
+            ->getMock();
+
+        $cartsApiMock->expects($this->once())
+            ->method('getApiCustomersOptIn')
+            ->with(self::MAGENTO_STORE_ID)
+            ->willReturn($optinStatus);
+        $cartsApiMock->expects($this->once())
+            ->method('getCountryModel')
+            ->with($billingAddressMock)
+            ->willReturn($country);
+
+        $cartModelMock->expects($this->once())
+            ->method('getCustomerFirstname')
+            ->willReturn($firstName);
+        $cartModelMock->expects($this->once())
+            ->method('getCustomerLastname')
+            ->willReturn($lastName);
+        $cartModelMock->expects($this->once())
+            ->method('getBillingAddress')
+            ->willReturn($billingAddressMock);
+
+        $billingAddressMock->expects($this->once())
+            ->method('getStreet')
+            ->willReturn($street);
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getCity')
+            ->willReturnOnConsecutiveCalls(
+                $city,
+                $city
+            );
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getRegion')
+            ->willReturnOnConsecutiveCalls(
+                $region,
+                $region
+            );
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getRegionCode')
+            ->willReturnOnConsecutiveCalls(
+                $regionCode,
+                $regionCode
+            );
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getPostcode')
+            ->willReturnOnConsecutiveCalls(
+                $postCode,
+                $postCode
+            );
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getCountry')
+            ->willReturnOnConsecutiveCalls(
+                $country,
+                $country
+            );
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getCompany')
+            ->willReturnOnConsecutiveCalls(
+                $company,
+                $company
+            );
+
+        $cartsApiMock->_getCustomer($cartModelMock, self::MAGENTO_STORE_ID);
+    }
 }

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/OrdersTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/OrdersTest.php
@@ -242,19 +242,14 @@ class Ebizmarts_MailChimp_Model_Api_OrdersTest extends PHPUnit_Framework_TestCas
             ->getMock();
 
         $itemsOrderCollection = $this->getMockBuilder(Mage_Sales_Model_Resource_Order_Item_Collection::class)
+            ->disableOriginalConstructor()
             ->setMethods(array('getIterator'))
             ->getMock();
 
-        $itemOrderMock = $this->getMockBuilder(Mage_Sales_Model_Resource_Order_Item::class)
+        $itemOrderMock = $this->getMockBuilder(Mage_Sales_Model_Order_Item::class)
+            ->disableOriginalConstructor()
             ->setMethods(array('getProductId', 'getProductOptions', 'getQtyOrdered', 'getPrice', 'getDiscountAmount'))
             ->getMock();
-
-        $items = array();
-        $items[] = $itemOrderMock;
-        $items[] = $itemOrderMock;
-        $items[] = $itemOrderMock;
-        $items[] = $itemOrderMock;
-        $items[] = $itemOrderMock;
 
         $productModelMock = $this->getMockBuilder(Mage_Catalog_Model_Product::class)
             ->setMethods(array('getIdBySku'))

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/OrdersTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/OrdersTest.php
@@ -240,11 +240,11 @@ class Ebizmarts_MailChimp_Model_Api_OrdersTest extends PHPUnit_Framework_TestCas
             ))
             ->getMock();
 
-        $commentCollectionMock = $this->getMockBuilder(Mage_Sales_Model_Resource_Order_Status_History_Collection::class)
+        $commentCollectionMock = $this->getMockBuilder(Mage_Sales_Model_Resource_Order_Invoice_Comment_Collection::class)
             ->setMethods(array('getIterator'))
             ->getMock();
 
-        $commentModelMock = $this->getMockBuilder(Mage_Sales_Model_Resource_Order_Status_History::class)
+        $commentModelMock = $this->getMockBuilder(Mage_Sales_Model_Resource_Order_Invoice_Comment::class)
             ->setMethods(array('getCreatedAt'))
             ->getMock();
 

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/OrdersTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/OrdersTest.php
@@ -191,6 +191,9 @@ class Ebizmarts_MailChimp_Model_Api_OrdersTest extends PHPUnit_Framework_TestCas
         $arraySate = array(array('neq' => 'canceled'), array('neq' => 'closed'));
         $customerEmailString = 'customer_email';
         $arrayCustomerEmail = array('eq' => $customerEmail);
+        $qtyOrdered = 2;
+        $price = 210;
+        $discountAmount = 0;
 
         $helperMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
             ->disableOriginalConstructor()
@@ -245,6 +248,13 @@ class Ebizmarts_MailChimp_Model_Api_OrdersTest extends PHPUnit_Framework_TestCas
         $itemOrderMock = $this->getMockBuilder(Mage_Sales_Model_Resource_Order_Item::class)
             ->setMethods(array('getProductId', 'getProductOptions', 'getQtyOrdered', 'getPrice', 'getDiscountAmount'))
             ->getMock();
+
+        $items = array();
+        $items[] = $itemOrderMock;
+        $items[] = $itemOrderMock;
+        $items[] = $itemOrderMock;
+        $items[] = $itemOrderMock;
+        $items[] = $itemOrderMock;
 
         $productModelMock = $this->getMockBuilder(Mage_Catalog_Model_Product::class)
             ->setMethods(array('getIdBySku'))
@@ -427,6 +437,15 @@ class Ebizmarts_MailChimp_Model_Api_OrdersTest extends PHPUnit_Framework_TestCas
         $itemOrderMock->expects($this->once())
             ->method('getProductOptions')
             ->willReturn($options);
+        $itemOrderMock->expects($this->once())
+            ->method('getQtyOrdered')
+            ->willReturn($qtyOrdered);
+        $itemOrderMock->expects($this->once())
+            ->method('getPrice')
+            ->willReturn($price);
+        $itemOrderMock->expects($this->once())
+            ->method('getDiscountAmount')
+            ->willReturn($discountAmount);
 
         $productModelMock->expects($this->once())
             ->method('getIdBySku')

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/OrdersTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/OrdersTest.php
@@ -203,7 +203,6 @@ class Ebizmarts_MailChimp_Model_Api_OrdersTest extends PHPUnit_Framework_TestCas
                 'getPromoData',
                 '_getMailChimpStatus',
                 'isOrderCanceled',
-                'isTheOrderCommentCanceled',
                 'isTypeProduct',
                 'getHelper',
                 'isItemConfigurable',
@@ -229,7 +228,6 @@ class Ebizmarts_MailChimp_Model_Api_OrdersTest extends PHPUnit_Framework_TestCas
                 'getBaseShippingAmount',
                 'getCreatedAt',
                 'getUpdatedAt',
-                'getStatusHistoryCollection',
                 'getAllVisibleItems',
                 'getCustomerEmail',
                 'getId',
@@ -238,14 +236,6 @@ class Ebizmarts_MailChimp_Model_Api_OrdersTest extends PHPUnit_Framework_TestCas
                 'getBillingAddress',
                 'getShippingAddress'
             ))
-            ->getMock();
-
-        $commentCollectionMock = $this->getMockBuilder(Mage_Sales_Model_Resource_Order_Invoice_Comment_Collection::class)
-            ->setMethods(array('getIterator'))
-            ->getMock();
-
-        $commentModelMock = $this->getMockBuilder(Mage_Sales_Model_Resource_Order_Invoice_Comment::class)
-            ->setMethods(array('getCreatedAt'))
             ->getMock();
 
         $itemsOrderCollection = $this->getMockBuilder(Mage_Sales_Model_Resource_Order_Item_Collection::class)
@@ -344,9 +334,6 @@ class Ebizmarts_MailChimp_Model_Api_OrdersTest extends PHPUnit_Framework_TestCas
             ->method('getUpdatedAt')
             ->willReturn($updatedAtForeign);
         $orderMock->expects($this->once())
-            ->method('getStatusHistoryCollection')
-            ->willReturn($commentCollectionMock);
-        $orderMock->expects($this->once())
             ->method('getAllVisibleItems')
             ->willReturn($itemsOrderCollection);
         $orderMock->expects($this->exactly(3))
@@ -398,10 +385,7 @@ class Ebizmarts_MailChimp_Model_Api_OrdersTest extends PHPUnit_Framework_TestCas
             ->willReturn($statusArray);
         $ordersApiMock->expects($this->once())
             ->method('isOrderCanceled')
-            ->willReturn(true);
-        $ordersApiMock->expects($this->once())
-            ->method('isTheOrderCommentCanceled')
-            ->willReturn(true);
+            ->willReturn(false);
         $ordersApiMock->expects($this->once())
             ->method('isTypeProduct')
             ->willReturn($isTypeProduct);
@@ -432,14 +416,6 @@ class Ebizmarts_MailChimp_Model_Api_OrdersTest extends PHPUnit_Framework_TestCas
         $ordersApiMock->expects($this->once())
             ->method('getResourceModelOrderCollection')
             ->willReturn($orderCollectionMock);
-
-        $commentCollectionMock->expects($this->once())
-            ->method('getIterator')
-            ->willReturn(new ArrayIterator(array($commentModelMock)));
-
-        $commentModelMock->expects($this->once())
-            ->method('getCreatedAt')
-            ->willReturn($orderCancelDate);
 
         $itemsOrderCollection->expects($this->once())
             ->method('getIterator')


### PR DESCRIPTION
- Removed the API call to get email of the customer from the function _getCustomer in the file Carts.php
- Implemented tests for _getCustomer and makeCart.
- Removed the API call to get email of the customer from the function GeneratePOSTPayload in the file Orders.php.
- Implemented test for GeneratePOSTPayload.
- Changed how the id of the customer is created at _buildCustomerData in the file Customers.php