### PR TITLE
Remove POST params if call is get in case the same API object is used in several calls.

### DIFF
--- a/lib/Ebizmarts/MailChimp.php
+++ b/lib/Ebizmarts/MailChimp.php
@@ -342,6 +342,7 @@ class Ebizmarts_MailChimp
         if ($hasParams && $method != Ebizmarts_MailChimp::GET) {
             curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
         } else {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, null);
             if ($hasParams) {
                 $_params = http_build_query($params);
                 $url .= '?' . $_params;
@@ -352,7 +353,6 @@ class Ebizmarts_MailChimp
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_VERBOSE, $this->_debug);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-
 
         $responseBody = curl_exec($ch);
 


### PR DESCRIPTION
closes #898 