### PR TITLE
Error syncing order with disabled product

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
@@ -638,6 +638,13 @@ class Ebizmarts_MailChimp_Model_Api_Batches
                     }
                     $error = $response->title . " : " . $response->detail;
 
+                    if ($type == Ebizmarts_MailChimp_Model_Config::IS_PRODUCT) {
+                        $dataProduct = $this->getDataProduct($helper, $mailchimpStoreId, $id, $type);
+                        if ($dataProduct->getMailchimpSyncDeleted() || $dataProduct->getMailchimpSyncError() == Ebizmarts_MailChimp_Model_Api_Products::PRODUCT_DISABLED_IN_MAGENTO) {
+                            $error = Ebizmarts_MailChimp_Model_Api_Products::PRODUCT_DISABLED_IN_MAGENTO;
+                        }
+                    }
+
                     $this->saveSyncData($id, $type, $mailchimpStoreId, null, $error, 0, null, null, 0, true);
 
                     $mailchimpErrors->setType($response->type);
@@ -656,7 +663,7 @@ class Ebizmarts_MailChimp_Model_Api_Batches
                     $mailchimpErrors->save();
                     $helper->logError($error);
                 } else {
-                    $syncDataItem = $helper->getEcommerceSyncDataItem($id, $type, $mailchimpStoreId);
+                    $syncDataItem = $this->getDataProduct($helper, $mailchimpStoreId, $id, $type);
                     if (!$syncDataItem->getMailchimpSyncModified()) {
                         $this->saveSyncData($id, $type, $mailchimpStoreId, null, null, 0, null, null, 1, true);
                     }
@@ -818,7 +825,7 @@ class Ebizmarts_MailChimp_Model_Api_Batches
     {
         $isMarkedAsDeleted = null;
         if ($type == Ebizmarts_MailChimp_Model_Config::IS_PRODUCT) {
-            $dataProduct = $helper->getEcommerceSyncDataItem($id, $type, $mailchimpStoreId);
+            $dataProduct = $this->getDataProduct($helper, $mailchimpStoreId, $id, $type);
             $isMarkedAsDeleted = $dataProduct->getMailchimpSyncDeleted();
 
             if (!$isMarkedAsDeleted || $dataProduct->getMailchimpSyncError() != Ebizmarts_MailChimp_Model_Api_Products::PRODUCT_DISABLED_IN_MAGENTO) {
@@ -852,5 +859,17 @@ class Ebizmarts_MailChimp_Model_Api_Batches
     protected function shouldFlagAsSynced($syncingFlag, $itemAmount)
     {
         return ($syncingFlag === '1' || $syncingFlag === null) && $itemAmount === 0;
+    }
+
+    /**
+     * @param $helper
+     * @param $mailchimpStoreId
+     * @param $id
+     * @param $type
+     * @return Varien_Object
+     */
+    protected function getDataProduct($helper, $mailchimpStoreId, $id, $type)
+    {
+        return $helper->getEcommerceSyncDataItem($id, $type, $mailchimpStoreId);
     }
 }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -782,7 +782,8 @@ class Ebizmarts_MailChimp_Model_Observer
                 if ($status[$product->getId()] == self::PRODUCT_IS_ENABLED) {
                     $dataProduct = $helper->getEcommerceSyncDataItem($product->getId(), Ebizmarts_MailChimp_Model_Config::IS_PRODUCT, $mailchimpStoreId);
                     $isMarkedAsDeleted = $dataProduct->getMailchimpSyncDeleted();
-                    if ($isMarkedAsDeleted) {
+                    $errorMessage = $dataProduct->getMailchimpSyncError();
+                    if ($isMarkedAsDeleted || $errorMessage == Ebizmarts_MailChimp_Model_Api_Products::PRODUCT_DISABLED_IN_MAGENTO) {
                         $dataProduct->delete();
                     } else {
                         $apiProduct->update($product->getId(), $mailchimpStoreId);


### PR DESCRIPTION
- Changed how the process the mailchimp response if the item is a product and the product is marked as disabled or have the message "This product was deleted because it is disabled in Magento."
- Now if the product was disabled and then enabled before delete the product to send it as new product to Mailchimp chack if the product isMarkedAsDeleted or if the product have the message: "This product was deleted because it is disabled in Magento."
- closes #943