### PR TITLE
Modifying the logic in Observer.php (subscriberSaveAfter() method) in order to make possible the immediately sending subscribers changes.

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
@@ -315,7 +315,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function isUseMagentoEmailsEnabled($scopeId)
     {
-        return $this->getConfigValueForScope(Ebizmarts_MailChimp_Model_Config::GENERAL_MAGENTO_MAIL, $scopeId);
+        return (int) $this->getConfigValueForScope(Ebizmarts_MailChimp_Model_Config::GENERAL_MAGENTO_MAIL, $scopeId);
     }
 
     /**

--- a/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
@@ -2825,7 +2825,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
             if ($syncDeleted) {
                 $subscriber->setData("mailchimp_sync_deleted", $syncDeleted);
             }
-            $subscriber->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_SOURCE);
+            $subscriber->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::MAILCHIMP_SUBSCRIBE);
             $subscriber->save();
         }
     }
@@ -3510,7 +3510,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
     protected function setMemberGeneralData($subscriber)
     {
         $subscriber->setImportMode(true);
-        $subscriber->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_SOURCE);
+        $subscriber->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::MAILCHIMP_SUBSCRIBE);
         $subscriber->setIsStatusChanged(true);
         $subscriber->save();
     }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Subscribers.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Subscribers.php
@@ -117,7 +117,7 @@ class Ebizmarts_MailChimp_Model_Api_Subscribers
                 $subscriber->setData("mailchimp_sync_delta", Varien_Date::now());
                 $subscriber->setData("mailchimp_sync_error", "");
                 $subscriber->setData("mailchimp_sync_modified", 0);
-                $subscriber->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_SOURCE);
+                $subscriber->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::MAILCHIMP_SUBSCRIBE);
                 $subscriber->save();
             }
 
@@ -288,7 +288,7 @@ class Ebizmarts_MailChimp_Model_Api_Subscribers
             }
 
             if ($saveSubscriber) {
-                $subscriber->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_SOURCE);
+                $subscriber->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::MAILCHIMP_SUBSCRIBE);
                 $subscriber->save();
             }
         }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -183,7 +183,7 @@ class Ebizmarts_MailChimp_Model_Observer
         $helper = $this->makeHelper();
         $isEnabled = $helper->isSubscriptionEnabled($storeId);
 
-        if ($isEnabled && $subscriber->getSubscriberSource() != Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_SOURCE) {
+        if ($isEnabled && $subscriber->getSubscriberSource() != Ebizmarts_MailChimp_Model_Subscriber::MAILCHIMP_SUBSCRIBE) {
             $statusChanged = $subscriber->getIsStatusChanged();
 
             //Override Magento status to always send double opt-in confirmation.
@@ -1186,7 +1186,7 @@ class Ebizmarts_MailChimp_Model_Observer
      */
     protected function isMailchimpSave($subscriberSource)
     {
-        return $subscriberSource === Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_SOURCE;
+        return $subscriberSource === Ebizmarts_MailChimp_Model_Subscriber::MAILCHIMP_SUBSCRIBE;
     }
 
 }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -212,7 +212,7 @@ class Ebizmarts_MailChimp_Model_Observer
         $isEnabled = $helper->isSubscriptionEnabled($storeViewId);
         $subscriberSource = $subscriber->getSubscriberSource();
 
-        if ($isEnabled && $subscriberSource !== Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_SOURCE) {
+        if ($isEnabled && !$this->isMailchimpSave($subscriberSource)) {
             $params = $this->getRequest()->getParams();
             $helper->saveInterestGroupData($params, $storeViewId, null, $subscriber);
 
@@ -1178,6 +1178,15 @@ class Ebizmarts_MailChimp_Model_Observer
     protected function isMagentoSubscription($subscriberSource)
     {
         return empty($subscriberSource);
+    }
+
+    /**
+     * @param $subscriberSource
+     * @return bool
+     */
+    protected function isMailchimpSave($subscriberSource)
+    {
+        return $subscriberSource === Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_SOURCE;
     }
 
 }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -1172,18 +1172,26 @@ class Ebizmarts_MailChimp_Model_Observer
         return $storeViewId;
     }
 
+    /**
+     * @param string $subscriberSource
+     * @return bool
+     */
     protected function isEmailConfirmationRequired($subscriberSource)
     {
         return $subscriberSource === Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_CONFIRMATION;
     }
 
+    /**
+     * @param string $subscriberSource
+     * @return bool
+     */
     protected function isMagentoSubscription($subscriberSource)
     {
         return empty($subscriberSource);
     }
 
     /**
-     * @param $subscriberSource
+     * @param string $subscriberSource
      * @return bool
      */
     protected function isMailchimpSave($subscriberSource)

--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -179,15 +179,17 @@ class Ebizmarts_MailChimp_Model_Observer
     public function subscriberSaveBefore(Varien_Event_Observer $observer)
     {
         $subscriber = $observer->getEvent()->getSubscriber();
+        $subscriberSource = $subscriber->getSubscriberSource();
         $storeId = $subscriber->getStoreId();
         $helper = $this->makeHelper();
         $isEnabled = $helper->isSubscriptionEnabled($storeId);
 
-        if ($isEnabled && $subscriber->getSubscriberSource() != Ebizmarts_MailChimp_Model_Subscriber::MAILCHIMP_SUBSCRIBE) {
+        if ($isEnabled && !$this->isMailchimpSave($subscriberSource)) {
             $statusChanged = $subscriber->getIsStatusChanged();
 
             //Override Magento status to always send double opt-in confirmation.
-            if ($statusChanged && $subscriber->getStatus() == Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED && $helper->isSubscriptionConfirmationEnabled($storeId) && !$helper->isUseMagentoEmailsEnabled($storeId)) {
+            if ($statusChanged && $subscriber->getStatus() == Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED &&
+                $helper->isSubscriptionConfirmationEnabled($storeId) && !$helper->isUseMagentoEmailsEnabled($storeId)) {
                 $subscriber->setStatus(Mage_Newsletter_Model_Subscriber::STATUS_NOT_ACTIVE);
                 $this->addSuccessIfRequired($helper);
             }

--- a/app/code/community/Ebizmarts/MailChimp/Model/ProcessWebhook.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/ProcessWebhook.php
@@ -102,7 +102,7 @@ class Ebizmarts_MailChimp_Model_ProcessWebhook
             if (!$newSubscriber->getId()) {
                 if ($oldSubscriber->getId()) {
                     $oldSubscriber->setSubscriberEmail($new);
-                    $oldSubscriber->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_SOURCE);
+                    $oldSubscriber->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::MAILCHIMP_SUBSCRIBE);
                     $oldSubscriber->save();
                 } else {
                     $helper->subscribeMember($newSubscriber);
@@ -236,7 +236,7 @@ class Ebizmarts_MailChimp_Model_ProcessWebhook
                         $saveRequired = true;
                     }
                     if ($saveRequired) {
-                        $subscriber->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_SOURCE);
+                        $subscriber->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::MAILCHIMP_SUBSCRIBE);
                         $subscriber->save();
                     }
                 } else {

--- a/app/code/community/Ebizmarts/MailChimp/Model/Subscriber.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Subscriber.php
@@ -9,6 +9,7 @@
 class Ebizmarts_MailChimp_Model_Subscriber extends Mage_Newsletter_Model_Subscriber
 {
     const SUBSCRIBE_SOURCE = 'MailChimp';
+    const SUBSCRIBE_CONFIRMATION = 'MailChimp_Confirmation';
 
     public function sendUnsubscriptionEmail()
     {
@@ -42,7 +43,7 @@ class Ebizmarts_MailChimp_Model_Subscriber extends Mage_Newsletter_Model_Subscri
         if ($this->getCode()==$code) {
             $this->setStatus(self::STATUS_SUBSCRIBED)
                 ->setIsStatusChanged(true)
-                ->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_SOURCE)
+                ->setSubscriberSource(Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_CONFIRMATION)
                 ->save();
             return true;
         }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Subscriber.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Subscriber.php
@@ -8,7 +8,7 @@
  */
 class Ebizmarts_MailChimp_Model_Subscriber extends Mage_Newsletter_Model_Subscriber
 {
-    const SUBSCRIBE_SOURCE = 'MailChimp';
+    const MAILCHIMP_SUBSCRIBE = 'MailChimp';
     const SUBSCRIBE_CONFIRMATION = 'MailChimp_Confirmation';
 
     public function sendUnsubscriptionEmail()

--- a/dev/tests/mailchimp/autoload.php
+++ b/dev/tests/mailchimp/autoload.php
@@ -10,7 +10,7 @@ define('MAGENTO_ROOT', $magentoRoot);
 //Set custom memory limit
 ini_set('memory_limit', '512M');
 //Include Magento libraries
-require_once(MAGENTO_ROOT .'/app/Mage.php');
+require_once(MAGENTO_ROOT .'../../../app/Mage.php');
 //Start the Magento application
 Mage::app('default');
 //Avoid issues "Headers already send"

--- a/dev/tests/mailchimp/autoload.php
+++ b/dev/tests/mailchimp/autoload.php
@@ -10,7 +10,7 @@ define('MAGENTO_ROOT', $magentoRoot);
 //Set custom memory limit
 ini_set('memory_limit', '512M');
 //Include Magento libraries
-require_once(MAGENTO_ROOT .'../../../app/Mage.php');
+require_once(MAGENTO_ROOT .'/app/Mage.php');
 //Start the Magento application
 Mage::app('default');
 //Avoid issues "Headers already send"

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
@@ -655,7 +655,7 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->setMethods(
                 array('makeHelper', 'getRequest', 'createEmailCookie', 'makeApiSubscriber',
-                    'getStoreViewIdBySubscriber', 'isEmailConfirmationRequired')
+                    'getStoreViewIdBySubscriber', 'isEmailConfirmationRequired', 'isMailchimpSave')
             )
             ->getMock();
 
@@ -694,6 +694,8 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $subscriberMock->expects($this->once())->method('getSubscriberSource')->willReturn($subscriberSource);
 
+        $observerMock->expects($this->once())->method('isMailchimpSave')->with($subscriberSource)->willReturn(false);
+
         $helperMock->expects($this->once())->method('isSubscriptionEnabled')->with($storeViewId)->willReturn(true);
 
         $observerMock->expects($this->once())->method('getRequest')->willReturn($requestMock);
@@ -730,7 +732,8 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->setMethods(
                 array('makeHelper', 'getRequest', 'createEmailCookie', 'makeApiSubscriber',
-                    'getStoreViewIdBySubscriber', 'isMagentoSubscription', 'isEmailConfirmationRequired')
+                    'getStoreViewIdBySubscriber', 'isMagentoSubscription', 'isEmailConfirmationRequired',
+                    'isMailchimpSave')
             )
             ->getMock();
 
@@ -769,6 +772,8 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
         $observerMock->expects($this->once())->method('makeHelper')->willReturn($helperMock);
 
         $subscriberMock->expects($this->once())->method('getSubscriberSource')->willReturn($subscriberSource);
+
+        $observerMock->expects($this->once())->method('isMailchimpSave')->with($subscriberSource)->willReturn(false);
 
         $helperMock->expects($this->once())->method('isSubscriptionEnabled')->with($storeViewId)->willReturn(true);
 

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ObserverTest.php
@@ -573,6 +573,7 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
     {
         $getStoreId = $data['getStoreId'];
         $storeId = 1;
+        $subscriberSource = null;
 
         $eventObserverMock = $this->getMockBuilder(Varien_Event_Observer::class)
             ->disableOriginalConstructor()
@@ -581,7 +582,7 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $observerMock = $this->getMockBuilder(Ebizmarts_MailChimp_Model_Observer::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('makeHelper', 'addSuccessIfRequired'))
+            ->setMethods(array('makeHelper', 'addSuccessIfRequired', 'isMailchimpSave'))
             ->getMock();
 
         $helperMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
@@ -606,28 +607,32 @@ class Ebizmarts_MailChimp_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
         $eventMock->expects($this->once())->method('getSubscriber')->willReturn($subscriberMock);
 
+        $subscriberMock->expects($this->once())->method('getSubscriberSource')->willReturn($subscriberSource);
+
         $subscriberMock->expects($this->once())->method('getStoreId')->willReturn($storeId);
 
         $observerMock->expects($this->once())->method('makeHelper')->willReturn($helperMock);
 
         $helperMock->expects($this->once())->method('isSubscriptionEnabled')->with($storeId)->willReturn(true);
 
-        $subscriberMock->expects($this->once())->method('getStatus')->willReturn(Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED);
+        $subscriberMock->expects($this->once())->method('getStatus')
+            ->willReturn(Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED);
+
+        $observerMock->expects($this->once())->method('isMailchimpSave')->with($subscriberSource)->willReturn(false);
 
         $subscriberMock->expects($this->once())->method('getIsStatusChanged')->willReturn(true);
 
-        $helperMock->expects($this->once())->method('isSubscriptionConfirmationEnabled')->with($storeId)->willReturn(true);
+        $helperMock->expects($this->once())->method('isSubscriptionConfirmationEnabled')->with($storeId)
+            ->willReturn(true);
 
         $helperMock->expects($this->once())->method('isUseMagentoEmailsEnabled')->with($storeId)->willReturn(false);
 
-        $subscriberMock->expects($this->once())->method('setStatus')->with(Mage_Newsletter_Model_Subscriber::STATUS_NOT_ACTIVE);
+        $subscriberMock->expects($this->once())->method('setStatus')
+            ->with(Mage_Newsletter_Model_Subscriber::STATUS_NOT_ACTIVE);
 
         $observerMock->expects($this->once())->method('addSuccessIfRequired')->with($helperMock);
 
-        $subscriberMock->expects($this->once())->method('getSubscriberSource')->willReturn(null);
-
         $subscriberMock->expects($this->exactly($getStoreId))->method('getStoreId')->willReturn($storeId);
-
 
         $observerMock->subscriberSaveBefore($eventObserverMock);
     }

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ProcessWebhookTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/ProcessWebhookTest.php
@@ -48,7 +48,7 @@ class Ebizmarts_MailChimp_Model_ProcessWebhookTest extends PHPUnit_Framework_Tes
         $email  = $data['email'] = 'brian+enterprisex1@ebizmarts.com';
         $fname  = $data['merges']['FNAME'] = 'Enterprise1';
         $lname  = $data['merges']['LNAME'] = 'enterprise11';
-        $subscribeSource = Ebizmarts_MailChimp_Model_Subscriber::SUBSCRIBE_SOURCE;
+        $subscribeSource = Ebizmarts_MailChimp_Model_Subscriber::MAILCHIMP_SUBSCRIBE;
 
         $processWebhookMock = $this->getMockBuilder(Ebizmarts_MailChimp_Model_ProcessWebhook::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
Modifying isUseMagentoEmailsEnabled() return data type, in Data.php, in order to return an int.
Modifying the logic in Observer.php (subscriberSaveAfter() method) in order to make possible the immediately sending subscribers changes.
Adding new constant: const SUBSCRIBE_CONFIRMATION = 'MailChimp_Confirmation';
for knowing when email confirmation is required.
Modifying ObserverTest.php due to the changes made in Observer.php #996 closes