### PR TITLE
Mailchimp exception params fixed

### DIFF
--- a/lib/Ebizmarts/MailChimp.php
+++ b/lib/Ebizmarts/MailChimp.php
@@ -17,6 +17,7 @@ if (defined("COMPILER_INCLUDE_PATH")) {
     include_once dirname(__FILE__) . '/Ebizmarts/MailChimp/AutomationEmails.php';
     include_once dirname(__FILE__) . '/Ebizmarts/MailChimp/AutomationEmailsQueue.php';
     include_once dirname(__FILE__) . '/Ebizmarts/MailChimp/Exceptions.php';
+    include_once dirname(__FILE__) . '/Ebizmarts/MailChimp/MailChimp_HttpError.php';
     include_once dirname(__FILE__) . '/Ebizmarts/MailChimp/AuthorizedApps.php';
     include_once dirname(__FILE__) . '/Ebizmarts/MailChimp/Automation.php';
     include_once dirname(__FILE__) . '/Ebizmarts/MailChimp/BatchOperations.php';
@@ -75,6 +76,7 @@ if (defined("COMPILER_INCLUDE_PATH")) {
     include_once dirname(__FILE__) . '/MailChimp/AutomationEmails.php';
     include_once dirname(__FILE__) . '/MailChimp/AutomationEmailsQueue.php';
     include_once dirname(__FILE__) . '/MailChimp/Exceptions.php';
+    include_once dirname(__FILE__) . '/MailChimp/MailChimp_HttpError.php';
     include_once dirname(__FILE__) . '/MailChimp/AuthorizedApps.php';
     include_once dirname(__FILE__) . '/MailChimp/Automation.php';
     include_once dirname(__FILE__) . '/MailChimp/BatchOperations.php';
@@ -214,7 +216,7 @@ class Ebizmarts_MailChimp
     public function __construct($apiKey = null, $opts = array(), $userAgent = null)
     {
         if (!$apiKey) {
-            throw new MailChimp_Error("", "", "", 'You must provide a MailChimp API key');
+            throw new MailChimp_Error('You must provide a MailChimp API key');
         }
 
         $this->_apiKey = $apiKey;
@@ -398,7 +400,7 @@ class Ebizmarts_MailChimp
 
 
         if (curl_error($ch)) {
-            throw new MailChimp_Error($url, $method, $params, "API call to $url failed: " . curl_error($ch));
+            throw new MailChimp_HttpError($url, $method, $params, "API call to $url failed: " . curl_error($ch));
         }
 
         if (floor($info['http_code'] / 100) >= 4) {
@@ -406,7 +408,7 @@ class Ebizmarts_MailChimp
             $errors = array_key_exists('errors', $result) ? $result['errors'] : null;
             $title = array_key_exists('title', $result) ? $result['title'] : '';
 
-            throw new MailChimp_Error($this->_root . $url, $method, $params, $title, $detail, $errors);
+            throw new MailChimp_HttpError($this->_root . $url, $method, $params, $title, $detail, $errors);
         }
 
         return $result;

--- a/lib/Ebizmarts/MailChimp.php
+++ b/lib/Ebizmarts/MailChimp.php
@@ -398,17 +398,21 @@ class Ebizmarts_MailChimp
 
         $result = json_decode($responseBody, true);
 
-
-        if (curl_error($ch)) {
-            throw new MailChimp_HttpError($url, $method, $params, "API call to $url failed: " . curl_error($ch));
+        $curlError = curl_error();
+        if (!empty($curlError)) {
+            throw new MailChimp_HttpError($url, $method, $params, '', "API call to $url failed: " . curl_error($ch));
         }
 
         if (floor($info['http_code'] / 100) >= 4) {
-            $detail = array_key_exists('detail', $result) ? $result['detail'] : '';
-            $errors = array_key_exists('errors', $result) ? $result['errors'] : null;
-            $title = array_key_exists('title', $result) ? $result['title'] : '';
+            if (is_array($result)) {
+                $detail = array_key_exists('detail', $result) ? $result['detail'] : '';
+                $errors = array_key_exists('errors', $result) ? $result['errors'] : null;
+                $title = array_key_exists('title', $result) ? $result['title'] : '';
 
-            throw new MailChimp_HttpError($this->_root . $url, $method, $params, $title, $detail, $errors);
+                throw new MailChimp_HttpError($this->_root . $url, $method, $params, $title, $detail, $errors);
+            } else {
+                throw new MailChimp_HttpError($this->_root . $url, $method, $params, $result);
+            }
         }
 
         return $result;

--- a/lib/Ebizmarts/MailChimp.php
+++ b/lib/Ebizmarts/MailChimp.php
@@ -214,7 +214,7 @@ class Ebizmarts_MailChimp
     public function __construct($apiKey = null, $opts = array(), $userAgent = null)
     {
         if (!$apiKey) {
-            throw new MailChimp_Error('You must provide a MailChimp API key');
+            throw new MailChimp_Error("", "","", 'You must provide a MailChimp API key');
         }
 
         $this->_apiKey = $apiKey;

--- a/lib/Ebizmarts/MailChimp.php
+++ b/lib/Ebizmarts/MailChimp.php
@@ -214,7 +214,7 @@ class Ebizmarts_MailChimp
     public function __construct($apiKey = null, $opts = array(), $userAgent = null)
     {
         if (!$apiKey) {
-            throw new MailChimp_Error("", "","", 'You must provide a MailChimp API key');
+            throw new MailChimp_Error("", "", "", 'You must provide a MailChimp API key');
         }
 
         $this->_apiKey = $apiKey;

--- a/lib/Ebizmarts/MailChimp.php
+++ b/lib/Ebizmarts/MailChimp.php
@@ -398,7 +398,7 @@ class Ebizmarts_MailChimp
 
         $result = json_decode($responseBody, true);
 
-        $curlError = curl_error();
+        $curlError = curl_error($ch);
         if (!empty($curlError)) {
             throw new MailChimp_HttpError($url, $method, $params, '', "API call to $url failed: " . curl_error($ch));
         }

--- a/lib/Ebizmarts/MailChimp.php
+++ b/lib/Ebizmarts/MailChimp.php
@@ -398,7 +398,7 @@ class Ebizmarts_MailChimp
 
 
         if (curl_error($ch)) {
-            throw new MailChimp_Error("API call to $url failed: " . curl_error($ch));
+            throw new MailChimp_Error($url, $method, $params, "API call to $url failed: " . curl_error($ch));
         }
 
         if (floor($info['http_code'] / 100) >= 4) {

--- a/lib/Ebizmarts/MailChimp/Exceptions.php
+++ b/lib/Ebizmarts/MailChimp/Exceptions.php
@@ -49,7 +49,7 @@ class MailChimp_Error extends Exception
      */
     protected $_mailchimpParams;
 
-    public function __construct($method = "", $params = "", $url = "", $title = "", $details = "", $errors = null)
+    public function __construct($url = "", $method = "", $params = "", $title = "", $details = "", $errors = null)
     {
         $titleComplete = $title . " for Api Call: " . $url;
         parent::__construct($titleComplete . " - " . $details);
@@ -64,7 +64,9 @@ class MailChimp_Error extends Exception
 
     public function getFriendlyMessage()
     {
-        $friendlyMessage = $this->_mailchimpTitle . " for Api Call: [" . $this->_mailchimpUrl. "] using method [".$this->_mailchimpMethod."]\n";
+        $friendlyMessage = $this->_mailchimpTitle . " for Api Call: ["
+            . $this->_mailchimpUrl. "] using method ["
+            .$this->_mailchimpMethod."]\n";
         $friendlyMessage .= "\tDetail: [".$this->_mailchimpDetails."]\n";
         if (!empty($this->_mailchimpErrors)) {
             $errorDetails = "";
@@ -74,10 +76,16 @@ class MailChimp_Error extends Exception
                 $line = "\t\t field [$field] : $message\n";
                 $errorDetails .= $line;
             }
+
             $friendlyMessage .= "\tErrors:\n".$errorDetails;
         }
 
-        $friendlyMessage .= "\tParams:\n\t\t".$this->_mailchimpParams;
+        if (!is_array($this->_mailchimpParams)) {
+            $friendlyMessage .= "\tParams:\n\t\t".$this->_mailchimpParams;
+        } elseif (!empty($this->_mailchimpParams)) {
+            $friendlyMessage .= "\tParams:\n\t\t" . json_encode($this->_mailchimpParams) . "\n";
+        }
+
         return $friendlyMessage;
     }
 

--- a/lib/Ebizmarts/MailChimp/Exceptions.php
+++ b/lib/Ebizmarts/MailChimp/Exceptions.php
@@ -15,133 +15,20 @@ class MailChimp_Error extends Exception
 {
 
     /**
-     * @var array
-     */
-    protected $_mailchimpErrors;
-
-    /**
      * @var string
      */
-    protected $_mailchimpTitleComplete;
+    protected $_mailchimpMessage;
 
-    /**
-     * @var string
-     */
-    protected $_mailchimpDetails;
-
-    /**
-     * @var string
-     */
-    protected $_mailchimpTitle;
-
-    /**
-     * @var string
-     */
-    protected $_mailchimpUrl;
-
-    /**
-     * @var string
-     */
-    protected $_mailchimpMethod;
-
-    /**
-     * @var string
-     */
-    protected $_mailchimpParams;
-
-    public function __construct($url = "", $method = "", $params = "", $title = "", $details = "", $errors = null)
+    public function __construct($message = "")
     {
-        $titleComplete = $title . " for Api Call: " . $url;
-        parent::__construct($titleComplete . " - " . $details);
-        $this->_mailchimpTitleComplete = $titleComplete;
-        $this->_mailchimpDetails = $details;
-        $this->_mailchimpErrors = $errors;
-        $this->_mailchimpUrl = $url;
-        $this->_mailchimpTitle = $title;
-        $this->_mailchimpMethod = $method;
-        $this->_mailchimpParams = $params;
+        $this->_mailchimpMessage = $message;
+        parent::__construct($message);
     }
 
     public function getFriendlyMessage()
     {
-        $friendlyMessage = $this->_mailchimpTitle . " for Api Call: ["
-            . $this->_mailchimpUrl. "] using method ["
-            .$this->_mailchimpMethod."]\n";
-        $friendlyMessage .= "\tDetail: [".$this->_mailchimpDetails."]\n";
-        if (!empty($this->_mailchimpErrors)) {
-            $errorDetails = "";
-            foreach ($this->_mailchimpErrors as $error) {
-                $field = array_key_exists('field', $error) ? $error['field'] : '';
-                $message = array_key_exists('message', $error) ? $error['message'] : '';
-                $line = "\t\t field [$field] : $message\n";
-                $errorDetails .= $line;
-            }
-
-            $friendlyMessage .= "\tErrors:\n".$errorDetails;
-        }
-
-        if (!is_array($this->_mailchimpParams)) {
-            $friendlyMessage .= "\tParams:\n\t\t".$this->_mailchimpParams;
-        } elseif (!empty($this->_mailchimpParams)) {
-            $friendlyMessage .= "\tParams:\n\t\t" . json_encode($this->_mailchimpParams) . "\n";
-        }
+        $friendlyMessage = "Mailchimp error with the next message: " . $this->_mailchimpMessage;
 
         return $friendlyMessage;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMailchimpTitleComplete()
-    {
-        return $this->_mailchimpTitleComplete;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMailchimpDetails()
-    {
-        return $this->_mailchimpDetails;
-    }
-
-    /**
-     * @return array|null
-     */
-    public function getMailchimpErrors()
-    {
-        return $this->_mailchimpErrors;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMailchimpTitle()
-    {
-        return $this->_mailchimpTitle;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMailchimpUrl()
-    {
-        return $this->_mailchimpUrl;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMailchimpMethod()
-    {
-        return $this->_mailchimpMethod;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMailchimpParams()
-    {
-        return $this->_mailchimpParams;
     }
 }

--- a/lib/Ebizmarts/MailChimp/Mailchimp_HttpError.php
+++ b/lib/Ebizmarts/MailChimp/Mailchimp_HttpError.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * mailchimp-lib Magento Component
+ *
+ * @category  Ebizmarts
+ * @package   mailchimp-lib
+ * @author    Ebizmarts Team <info@ebizmarts.com>
+ * @copyright Ebizmarts (http://ebizmarts.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @date:     4/27/16 4:45 PM
+ * @file:     Exceptions.php
+ */
+
+class MailChimp_HttpError extends MailChimp_Error
+{
+
+    /**
+     * @var array
+     */
+    protected $_mailchimpErrors;
+
+    /**
+     * @var string
+     */
+    protected $_mailchimpTitleComplete;
+
+    /**
+     * @var string
+     */
+    protected $_mailchimpDetails;
+
+    /**
+     * @var string
+     */
+    protected $_mailchimpTitle;
+
+    /**
+     * @var string
+     */
+    protected $_mailchimpUrl;
+
+    /**
+     * @var string
+     */
+    protected $_mailchimpMethod;
+
+    /**
+     * @var string
+     */
+    protected $_mailchimpParams;
+
+    public function __construct($url = "", $method = "", $params = "", $title = "", $details = "", $errors = null)
+    {
+        $titleComplete = $title . " for Api Call: " . $url;
+        parent::__construct($titleComplete . " - " . $details);
+        $this->_mailchimpTitleComplete = $titleComplete;
+        $this->_mailchimpDetails = $details;
+        $this->_mailchimpErrors = $errors;
+        $this->_mailchimpUrl = $url;
+        $this->_mailchimpTitle = $title;
+        $this->_mailchimpMethod = $method;
+        $this->_mailchimpParams = $params;
+    }
+
+    public function getFriendlyMessage()
+    {
+        $friendlyMessage = $this->_mailchimpTitle . " for Api Call: ["
+            . $this->_mailchimpUrl. "] using method ["
+            .$this->_mailchimpMethod."]\n";
+        $friendlyMessage .= "\tDetail: [".$this->_mailchimpDetails."]\n";
+        if (!empty($this->_mailchimpErrors)) {
+            $errorDetails = "";
+            foreach ($this->_mailchimpErrors as $error) {
+                $field = array_key_exists('field', $error) ? $error['field'] : '';
+                $message = array_key_exists('message', $error) ? $error['message'] : '';
+                $line = "\t\t field [$field] : $message\n";
+                $errorDetails .= $line;
+            }
+
+            $friendlyMessage .= "\tErrors:\n".$errorDetails;
+        }
+
+        if (!is_array($this->_mailchimpParams)) {
+            $friendlyMessage .= "\tParams:\n\t\t".$this->_mailchimpParams;
+        } elseif (!empty($this->_mailchimpParams)) {
+            $friendlyMessage .= "\tParams:\n\t\t" . json_encode($this->_mailchimpParams) . "\n";
+        }
+
+        return $friendlyMessage;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailchimpTitleComplete()
+    {
+        return $this->_mailchimpTitleComplete;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailchimpDetails()
+    {
+        return $this->_mailchimpDetails;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getMailchimpErrors()
+    {
+        return $this->_mailchimpErrors;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailchimpTitle()
+    {
+        return $this->_mailchimpTitle;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailchimpUrl()
+    {
+        return $this->_mailchimpUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailchimpMethod()
+    {
+        return $this->_mailchimpMethod;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailchimpParams()
+    {
+        return $this->_mailchimpParams;
+    }
+}


### PR DESCRIPTION
- Changed the order of the mailchimp error exception params.
- Fixed "params" var "array to string conversion".

Ref. #1021 .