### PR TITLE
 serialize() and unserialize() via Zend_Serializer class

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/System/Config/Form/Field/Mapfields.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/System/Config/Form/Field/Mapfields.php
@@ -15,21 +15,26 @@ class Ebizmarts_MailChimp_Block_Adminhtml_System_Config_Form_Field_Mapfields
 {
     protected $_customerAttributes;
 
+    /**
+     * @var Ebizmarts_MailChimp_Helper_Data
+     */
+    protected $_helper;
+
     public function __construct()
     {
-        $helper = $this->makeHelper();
+        $this->_helper = $this->makeHelper();
 
         $this->addColumn(
             'mailchimp',
             array(
-            'label' => $helper->__('Mailchimp'),
+            'label' => $this->_helper->__('Mailchimp'),
             'style' => 'width:120px',
             )
         );
         $this->addColumn(
             'magento',
             array(
-            'label' => $helper->__('Customer'),
+            'label' => $this->_helper->__('Customer'),
             'style' => 'width:120px',
             )
         );
@@ -49,9 +54,10 @@ class Ebizmarts_MailChimp_Block_Adminhtml_System_Config_Form_Field_Mapfields
             }
         }
 
-        $scopeArray = $helper->getCurrentScope();
-        $mapFields = $helper->getCustomMergeFieldsSerialized($scopeArray['scope_id'], $scopeArray['scope']);
-        $customFieldTypes = unserialize($mapFields);
+        $scopeArray = $this->_helper->getCurrentScope();
+        $mapFields = $this->_helper->getCustomMergeFieldsSerialized($scopeArray['scope_id'], $scopeArray['scope']);
+        $customFieldTypes = $this->_helper->unserialize($mapFields);
+
         if (is_array($customFieldTypes)) {
             foreach ($customFieldTypes as $customFieldType) {
                 $label = $customFieldType['label'];

--- a/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
@@ -4990,7 +4990,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function serialize($value, array $options = array())
     {
-        Zend_Serializer::serialize($value, $options);
+        return Zend_Serializer::serialize($value, $options);
     }
 
     /**
@@ -5003,6 +5003,6 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function unserialize($serialized, array $options = array())
     {
-        Zend_Serializer::unserialize($serialized, $options);
+        return Zend_Serializer::unserialize($serialized, $options);
     }
 }

--- a/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
@@ -1373,13 +1373,15 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
     public function createMergeFields($scopeId, $scope)
     {
         $listId = $this->getGeneralList($scopeId, $scope);
-        $maps = unserialize($this->getMapFields($scopeId, $scope));
-        $customFieldTypes = unserialize($this->getCustomMergeFieldsSerialized($scopeId, $scope));
+        $maps = $this->unserialize($this->getMapFields($scopeId, $scope));
+        $customFieldTypes = $this->unserialize($this->getCustomMergeFieldsSerialized($scopeId, $scope));
+
         try {
             $api = $this->getApi($scopeId, $scope);
             $mailchimpFields = array();
+
             try {
-                $mailchimpFields = $api->lists->mergeFields->getAll($listId, null, null, 50);
+                $mailchimpFields = $api->getLists()->getMergeFields()->getAll($listId, null, null, 50);
             } catch (MailChimp_Error $e) {
                 $this->logError($e->getFriendlyMessage());
             }
@@ -1389,6 +1391,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
                     $customAtt = $map['magento'];
                     $chimpTag = $map['mailchimp'];
                     $alreadyExists = false;
+
                     foreach ($mailchimpFields['merge_fields'] as $mailchimpField) {
                         if ($mailchimpField['tag'] == $chimpTag || strtoupper($chimpTag) == 'EMAIL') {
                             $alreadyExists = true;
@@ -1996,7 +1999,8 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function getCustomMergeFields($scopeId, $scope = null)
     {
-        $customMergeFields = unserialize($this->getCustomMergeFieldsSerialized($scopeId, $scope));
+        $customMergeFields = $this->unserialize($this->getCustomMergeFieldsSerialized($scopeId, $scope));
+
         if (!$customMergeFields) {
             $customMergeFields = array();
         }
@@ -2027,6 +2031,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
         $url = null;
         $storeId = $this->getMageApp()->getStore()->getId();
         $mailchimpStoreId = $this->getMCStoreId($storeId);
+
         if ($this->isEcomSyncDataEnabled($storeId)) {
             $currentUrl = $this->getConfigValueForScope(
                 Ebizmarts_MailChimp_Model_Config::ECOMMERCE_MC_JS_URL . "_$mailchimpStoreId",
@@ -2057,10 +2062,12 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
     public function retrieveAndSaveMCJsUrlInConfig($scopeId, $scope = 'stores')
     {
         $mcJsUrlSaved = false;
+
         try {
             $api = $this->getApi($scopeId, $scope);
             $mailchimpStoreId = $this->getMCStoreId($scopeId, $scope);
             $response = $api->getEcommerce()->getStores()->get($mailchimpStoreId, 'connected_site');
+
             if (isset($response['connected_site']['site_script']['url'])) {
                 $url = $response['connected_site']['site_script']['url'];
                 $configValues = array(
@@ -2136,12 +2143,15 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
             if (!$dateHelper->timePassed($initialTime)) {
                 //migrate products
                 $this->_migrateProductsFrom115($mailchimpStoreId, $initialTime);
+
                 if (!$dateHelper->timePassed($initialTime)) {
                     //migrate orders
                     $this->_migrateOrdersFrom115($mailchimpStoreId, $initialTime);
+
                     if (!$dateHelper->timePassed($initialTime)) {
                         //migrate carts
                         $finished = $this->_migrateCartsFrom115($mailchimpStoreId, $initialTime);
+
                         if ($finished) {
                             $this->_migrateFrom115dropColumn($arrayMigrationConfigData);
                         }
@@ -2159,6 +2169,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
 
         //Remove attributes no longer used
         $setup = Mage::getResourceModel('catalog/setup', 'catalog_setup');
+
         try {
             $setup->removeAttribute('catalog_product', 'mailchimp_sync_delta');
             $setup->removeAttribute('catalog_product', 'mailchimp_sync_error');
@@ -2171,6 +2182,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
         }
 
         $coreResource = $this->getCoreResource();
+
         try {
             $quoteTable = $coreResource->getTableName('sales/quote');
             $connectionQuote = $setup->getConnection();
@@ -2204,8 +2216,8 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
     {
         try {
             $entityType = Mage::getSingleton('eav/config')->getEntityType('customer');
-            $attribute = Mage::getModel('customer/attribute')
-                ->loadByCode($entityType, 'mailchimp_sync_delta');
+            $attribute = Mage::getModel('customer/attribute')->loadByCode($entityType, 'mailchimp_sync_delta');
+
             if ($attribute->getId()) {
                 $mailchimpTableName = $this->getCoreResource()->getTableName('mailchimp/ecommercesyncdata');
                 $customerCollection = Mage::getResourceModel('customer/customer_collection');
@@ -2229,6 +2241,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
                         $syncError = null;
                         $syncModified = null;
                         $syncDelta = $customerObject->getMailchimpSyncDelta();
+
                         if ($customer->getMailchimpSyncError()) {
                             $syncError = $customer->getMailchimpSyncError();
                         }
@@ -2265,8 +2278,8 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
         try {
             $entityType = Mage_Catalog_Model_Product::ENTITY;
             $attributeCode = 'mailchimp_sync_delta';
-            $attribute = Mage::getModel('eav/entity_attribute')
-                ->loadByCode($entityType, $attributeCode);
+            $attribute = Mage::getModel('eav/entity_attribute')->loadByCode($entityType, $attributeCode);
+
             if ($attribute->getId()) {
                 $mailchimpTableName = $this->getCoreResource()->getTableName('mailchimp/ecommercesyncdata');
                 $productCollection = Mage::getResourceModel('catalog/product_collection');
@@ -2277,9 +2290,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
                     . "' AND m4m.mailchimp_store_id = '" . $mailchimpStoreId . "'",
                     array('m4m.*')
                 );
-                $productCollection->getSelect()->where(
-                    "m4m.mailchimp_sync_delta IS null"
-                );
+                $productCollection->getSelect()->where("m4m.mailchimp_sync_delta IS null");
                 $this->_makeForCollectionItem(
                     $productCollection,
                     $mailchimpStoreId,
@@ -2294,6 +2305,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
                         );
                         $syncError = null;
                         $syncModified = null;
+
                         if ($product->getMailchimpSyncError()) {
                             $syncError = $product->getMailchimpSyncError();
                         }
@@ -2332,6 +2344,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
             $readConnection = $resource->getConnection('core_read');
             $tableName = $resource->getTableName('sales/order');
             $orderFields = $readConnection->describeTable($tableName);
+
             if (isset($orderFields['mailchimp_sync_delta'])) {
                 $mailchimpTableName = $resource->getTableName('mailchimp/ecommercesyncdata');
                 $orderCollection = Mage::getResourceModel('sales/order_collection');
@@ -2357,6 +2370,7 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
                         $syncModified = null;
                         $orderObject = $this->getSalesOrderModel()->load($orderId);
                         $syncDelta = $orderObject->getMailchimpSyncDelta();
+
                         if ($order->getMailchimpSyncError()) {
                             $syncError = $order->getMailchimpSyncError();
                         }
@@ -4964,5 +4978,31 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
             ),
             $where
         );
+    }
+
+    /**
+     * Generates a storable representation of a value using the default adapter.
+     *
+     * @param mixed $value
+     * @param array $options
+     * @return string
+     * @throws Zend_Serializer_Exception
+     */
+    public function serialize($value, array $options = array())
+    {
+        Zend_Serializer::serialize($value, $options);
+    }
+
+    /**
+     * Creates a PHP value from a stored representation using the default adapter.
+     *
+     * @param string $serialized
+     * @param array $options
+     * @return mixed
+     * @throws Zend_Serializer_Exception
+     */
+    public function unserialize($serialized, array $options = array())
+    {
+        Zend_Serializer::unserialize($serialized, $options);
     }
 }

--- a/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
@@ -4983,8 +4983,8 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Generates a storable representation of a value using the default adapter.
      *
-     * @param mixed $value
-     * @param array $options
+     * @param  mixed $value
+     * @param  array $options
      * @return string
      * @throws Zend_Serializer_Exception
      */
@@ -4996,8 +4996,8 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Creates a PHP value from a stored representation using the default adapter.
      *
-     * @param string $serialized
-     * @param array $options
+     * @param  string $serialized
+     * @param  array  $options
      * @return mixed
      * @throws Zend_Serializer_Exception
      */

--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Subscribers/MailchimpTags.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Subscribers/MailchimpTags.php
@@ -252,7 +252,7 @@ class Ebizmarts_MailChimp_Model_Api_Subscribers_MailchimpTags
      */
     protected function unserializeMapFields($mapFields)
     {
-        return unserialize($mapFields);
+        return $this->_mcHelper->unserialize($mapFields);
     }
 
     /**

--- a/app/code/community/Ebizmarts/MailChimp/Model/ProcessWebhook.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/ProcessWebhook.php
@@ -43,7 +43,7 @@ class Ebizmarts_MailChimp_Model_ProcessWebhook
         Mage::getModel('mailchimp/webhookrequest')
             ->setType($data['type'])
             ->setFiredAt($data['fired_at'])
-            ->setDataRequest(serialize($data['data']))
+            ->setDataRequest($this->_helper->serialize($data['data']))
             ->save();
     }
 
@@ -57,8 +57,10 @@ class Ebizmarts_MailChimp_Model_ProcessWebhook
         $collection = Mage::getModel('mailchimp/webhookrequest')->getCollection();
         $collection->addFieldToFilter('processed', array('eq' => 0));
         $collection->getSelect()->limit(self::BATCH_LIMIT);
+
         foreach ($collection as $webhookRequest) {
-            $data = unserialize($webhookRequest->getDataRequest());
+            $data = $this->_helper->unserialize($webhookRequest->getDataRequest());
+
             if ($data) {
                 switch ($webhookRequest->getType()) {
                 case 'subscribe':
@@ -78,8 +80,7 @@ class Ebizmarts_MailChimp_Model_ProcessWebhook
                 }
             }
 
-            $webhookRequest->setProcessed(1)
-                ->save();
+            $webhookRequest->setProcessed(1)->save();
         }
     }
 

--- a/app/code/community/Ebizmarts/MailChimp/Model/System/Config/Backend/Mapfield.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/System/Config/Backend/Mapfield.php
@@ -13,8 +13,15 @@
 class Ebizmarts_MailChimp_Model_System_Config_Backend_Mapfield
     extends Mage_Adminhtml_Model_System_Config_Backend_Serialized_Array
 {
+    /**
+     * @var Ebizmarts_MailChimp_Helper_Data
+     */
+    protected $_helper;
+
     protected function _afterLoad()
     {
+        $this->_helper = Mage::helper('mailchimp');
+
         if (!is_array($this->getValue())) {
             if (is_object($this->getValue())) {
                 $serializedValue = $this->getValue()->asArray();
@@ -23,9 +30,10 @@ class Ebizmarts_MailChimp_Model_System_Config_Backend_Mapfield
             }
 
             $unserializedValue = false;
+
             if (!empty($serializedValue)) {
                 try {
-                    $unserializedValue = unserialize($serializedValue);
+                    $unserializedValue = $this->_helper->unserialize($serializedValue);
                 } catch (Exception $e) {
                     Mage::logException($e);
                 }

--- a/app/code/community/Ebizmarts/MailChimp/controllers/Adminhtml/MergevarsController.php
+++ b/app/code/community/Ebizmarts/MailChimp/controllers/Adminhtml/MergevarsController.php
@@ -58,14 +58,13 @@ class Ebizmarts_MailChimp_Adminhtml_MergevarsController extends Mage_Adminhtml_C
             $customMergeFields[] = array('label' => $label, 'value' => $value, 'field_type' => $fieldType);
             $configValues = array(
                 array(
-                    Ebizmarts_MailChimp_Model_Config::GENERAL_CUSTOM_MAP_FIELDS, serialize($customMergeFields)
+                    Ebizmarts_MailChimp_Model_Config::GENERAL_CUSTOM_MAP_FIELDS, $helper->serialize($customMergeFields)
                 )
             );
             $helper->saveMailchimpConfig($configValues, $scopeArray['scope_id'], $scopeArray['scope']);
             Mage::getSingleton('core/session')->setMailChimpValue($value);
             Mage::getSingleton('core/session')->setMailChimpLabel($label);
-            Mage::getSingleton('adminhtml/session')
-                ->addSuccess($this->__('The custom value was added successfully.'));
+            Mage::getSingleton('adminhtml/session')->addSuccess($this->__('The custom value was added successfully.'));
         }
 
         $this->_redirect("*/*/addmergevar");

--- a/dev/tests/mailchimp/autoload.php
+++ b/dev/tests/mailchimp/autoload.php
@@ -10,7 +10,7 @@ define('MAGENTO_ROOT', $magentoRoot);
 //Set custom memory limit
 ini_set('memory_limit', '512M');
 //Include Magento libraries
-require_once MAGENTO_ROOT . '/app/Mage.php';
+require_once MAGENTO_ROOT . '../../../app/Mage.php';
 //Start the Magento application
 Mage::app('default');
 //Avoid issues "Headers already send"

--- a/dev/tests/mailchimp/autoload.php
+++ b/dev/tests/mailchimp/autoload.php
@@ -10,7 +10,7 @@ define('MAGENTO_ROOT', $magentoRoot);
 //Set custom memory limit
 ini_set('memory_limit', '512M');
 //Include Magento libraries
-require_once MAGENTO_ROOT . '../../../app/Mage.php';
+require_once MAGENTO_ROOT . '/app/Mage.php';
 //Start the Magento application
 Mage::app('default');
 //Avoid issues "Headers already send"

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Helper/DataTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Helper/DataTest.php
@@ -1907,4 +1907,176 @@ class Ebizmarts_MailChimp_Helper_DataTest extends PHPUnit_Framework_TestCase
         $helperDataMock->getMagentoStoresForMCStoreIdByScope($scopeId, $scope);
     }
 
+    public function testCreateMergeFields()
+    {
+        $scopeId = 0;
+        $scope = 'stores';
+        $listId = "b514eebd1a";
+        $mapFieldsSerialized = 'a:10:{s:18:"_1468601283719_719";a:2:{s:9:"mailchimp";s:7:"WEBSITE";' .
+            's:7:"magento";s:1:"1";}s:18:"_1468609069544_544";a:2:{s:9:"mailchimp";s:7:"STOREID";' .
+            's:7:"magento";s:1:"2";}s:18:"_1469026825907_907";a:2:{s:9:"mailchimp";s:9:"STORENAME";' .
+            's:7:"magento";s:1:"3";}s:18:"_1469027411717_717";a:2:{s:9:"mailchimp";s:6:"PREFIX";' .
+            's:7:"magento";s:1:"4";}s:18:"_1469027418285_285";a:2:{s:9:"mailchimp";s:5:"FNAME";' .
+            's:7:"magento";s:1:"5";}}';
+
+        $mapFieldsUnserialized = array(
+                "_1468601283719_719", array("mailchimp", "WEBSITE", "magento", "1"), "_1468609069544_544",
+                array("mailchimp", "STOREID", "magento", "2"), "_1469026825907_907",
+                array("mailchimp", "STORENAME", "magento", "3"),
+                "_1469027411717_717", array("mailchimp","PREFIX","magento", "4"), "_1469027418285_285",
+                array("mailchimp", "FNAME", "magento", "5")
+        );
+
+        $arrayMergeFieldsGetAll = array
+        (
+            "merge_fields" => array
+            (
+                0 => array
+                (
+                    "merge_id" => 3,
+                    "tag" => "ADDRESS",
+                    "name" => "Address",
+                    "type" => "address",
+                    "required" => "",
+                    "default_value" => "",
+                    "public" => "",
+                    "display_order" => 4,
+                    "options" => array("default_country" => 164),
+                    "help_text" => "",
+                    "list_id" => "b514eebd1a",
+                    "_links" => array
+                    (
+                        0 => array
+                        (
+                            "rel" => "self",
+                            "href" => "https://us20.api.mailchimp.com/3.0/lists/b514eebd1a/merge-fields/3",
+                            "method" => "GET",
+                            "targetSchema" => "https://us20.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+                        ),
+
+                        1 => array
+                        (
+                            "rel" => "parent",
+                            "href" => "https://us20.api.mailchimp.com/3.0/lists/b514eebd1a/merge-fields",
+                            "method" => "GET",
+                            "targetSchema" => "https://us20.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+                            "schema" => "https://us20.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+                        ),
+
+                        2 => array
+                        (
+                            "rel" => "update",
+                            "href" => "https://us20.api.mailchimp.com/3.0/lists/b514eebd1a/merge-fields/3",
+                            "method" => "PATCH",
+                            "targetSchema" => "https://us20.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+                            "schema" => "https://us20.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+                        ),
+
+                        3 => array
+                        (
+                            "rel" => "delete",
+                            "href" => "https://us20.api.mailchimp.com/3.0/lists/b514eebd1a/merge-fields/3",
+                            "method" => "DELETE",
+                        )
+
+                    )
+
+                )
+            )
+        );
+
+        $ebizmartsMailchimpMock = $this->getMockBuilder(Ebizmarts_MailChimp::class)
+                ->disableOriginalConstructor()->setMethods(array('getLists'))
+                ->getMock();
+
+        $mailchimpListsMock = $this->getMockBuilder(MailChimp_Lists::class)
+                ->disableOriginalConstructor()->setMethods(array('getMergeFields'))
+                ->getMock();
+
+        $mailchimpListsMergeFieldsMock = $this->getMockBuilder(MailChimp_ListsMergeFields::class)
+                ->disableOriginalConstructor()->setMethods(array('getAll'))
+                ->getMock();
+
+        $helperDataMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
+            ->disableOriginalConstructor()
+            ->setMethods(
+                array(
+                    'getGeneralList', 'getMapFields', 'unserialize', 'getCustomMergeFieldsSerialized',
+                    'getApi', '_createCustomFieldTypes',
+                )
+            )
+            ->getMock();
+
+        $helperDataMock->expects($this->once())->method('getGeneralList')->with($scopeId, $scope)->willReturn($listId);
+
+        $helperDataMock->expects($this->once())->method('getMapFields')
+            ->with($scopeId, $scope)->willReturn($mapFieldsSerialized);
+
+        $helperDataMock->expects($this->exactly(2))->method('unserialize')
+            ->withConsecutive(array($mapFieldsSerialized), array($mapFieldsSerialized))
+            ->willReturnOnConsecutiveCalls($mapFieldsUnserialized, $mapFieldsUnserialized);
+
+        $helperDataMock->expects($this->once())->method('getCustomMergeFieldsSerialized')
+            ->with($scopeId, $scope)->willReturn($mapFieldsSerialized);
+
+        $helperDataMock->expects($this->once())->method('getApi')->with($scopeId, $scope)
+            ->willReturn($ebizmartsMailchimpMock);
+
+        $ebizmartsMailchimpMock->expects($this->once())->method('getLists')
+        ->willReturn($mailchimpListsMock);
+
+        $mailchimpListsMock->expects($this->once())->method('getMergeFields')
+        ->willReturn($mailchimpListsMergeFieldsMock);
+
+        $mailchimpListsMergeFieldsMock->expects($this->once())->method('getAll')
+            ->with($listId, null, null, 50)
+            ->willReturn($arrayMergeFieldsGetAll);
+
+        $times = 10;//count($mapFieldsUnserialized) * count($arrayMergeFieldsGetAll);
+
+        $helperDataMock->expects($this->exactly($times))->method('_createCustomFieldTypes')
+            ->withConsecutive(
+                array($mapFieldsUnserialized), array($mapFieldsUnserialized),
+                array($mapFieldsUnserialized), array($mapFieldsUnserialized),
+                array($mapFieldsUnserialized), array($mapFieldsUnserialized),
+                array($mapFieldsUnserialized), array($mapFieldsUnserialized),
+                array($mapFieldsUnserialized), array($mapFieldsUnserialized)
+            );
+
+        $helperDataMock->createMergeFields($scopeId, $scope);
+    }
+
+    public function testGetCustomMergeFields()
+    {
+        $scopeId = 0;
+        $scope = 'stores';
+        $mapFieldsSerialized = 'a:10:{s:18:"_1468601283719_719";a:2:{s:9:"mailchimp";s:7:"WEBSITE";' .
+            's:7:"magento";s:1:"1";}s:18:"_1468609069544_544";a:2:{s:9:"mailchimp";s:7:"STOREID";' .
+            's:7:"magento";s:1:"2";}s:18:"_1469026825907_907";a:2:{s:9:"mailchimp";s:9:"STORENAME";' .
+            's:7:"magento";s:1:"3";}s:18:"_1469027411717_717";a:2:{s:9:"mailchimp";s:6:"PREFIX";' .
+            's:7:"magento";s:1:"4";}s:18:"_1469027418285_285";a:2:{s:9:"mailchimp";s:5:"FNAME";' .
+            's:7:"magento";s:1:"5";}}';
+
+        $mapFieldsUnserialized = array(
+            "_1468601283719_719", array("mailchimp", "WEBSITE", "magento", "1"), "_1468609069544_544",
+            array("mailchimp", "STOREID", "magento", "2"), "_1469026825907_907",
+            array("mailchimp", "STORENAME", "magento", "3"),
+            "_1469027411717_717", array("mailchimp","PREFIX","magento", "4"), "_1469027418285_285",
+            array("mailchimp", "FNAME", "magento", "5")
+        );
+
+        $helperDataMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('unserialize', 'getCustomMergeFieldsSerialized'))
+            ->getMock();
+
+        $helperDataMock->expects($this->once())->method('getCustomMergeFieldsSerialized')
+            ->with($scopeId, $scope)->willReturn($mapFieldsSerialized);
+
+        $helperDataMock->expects($this->once())->method('unserialize')
+            ->with($mapFieldsSerialized)
+            ->willReturn($mapFieldsUnserialized);
+
+        $helperDataMock->getCustomMergeFields($scopeId, $scope);
+    }
 }

--- a/lib/Ebizmarts/MailChimp/Lists.php
+++ b/lib/Ebizmarts/MailChimp/Lists.php
@@ -51,6 +51,14 @@ class MailChimp_Lists extends MailChimp_Abstract
     public $webhooks;
 
     /**
+     * @return MailChimp_ListsMergeFields
+     */
+    public function getMergeFields()
+    {
+        return $this->mergeFields;
+    }
+
+    /**
      * @return MailChimp_ListsInterestCategory
      */
     public function getInterestCategory()


### PR DESCRIPTION
Defining new two methods in Helper/Data.php: serialize and unserialize(), which use Zend_Serializer's methods:

https://framework.zend.com/manual/2.3/en/modules/zend.serializer.html,
instead using directly serialize and unserialize() which are deprecated according to MEQP standard.
Reusing the above mentioned methods in: Data.php, MailchimpTags.php, Mapfield.php, Mapfields.php, MergevarsController.php, ProcessWebhook.php
Updating test cases.
closes #1019