### PR TITLE
Adding a prefix: "[Invalid]: " to the apikeys which are not valid in …

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Mailchimpstores/Edit/Form.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Mailchimpstores/Edit/Form.php
@@ -47,14 +47,24 @@ class Ebizmarts_MailChimp_Block_Adminhtml_Mailchimpstores_Edit_Form extends Mage
             'class'     => 'fieldset',
             )
         );
+
         if (!$store->getId()) {
             $stores = Mage::app()->getStores();
             $apikeys = array();
+
             foreach ($stores as $s) {
-                $apikey = $helper->getApiKey($s->getStoreId());
+                $prefix = '';
+                $storeId = $s->getStoreId();
+
+                if(!$helper->ping($storeId)) {
+                    $prefix = '[Invalid]: ';
+                }
+
+                $apikey = $helper->getApiKey($storeId);
+
                 if (!array_key_exists($apikey, $apikeys)) {
                     $encryptedApiKey = $helper->encryptData($apikey);
-                    $apikeys[$encryptedApiKey] = $helper->mask($apikey);
+                    $apikeys[$encryptedApiKey] = $helper->mask($apikey, $prefix);
                 }
             }
 
@@ -67,6 +77,7 @@ class Ebizmarts_MailChimp_Block_Adminhtml_Mailchimpstores_Edit_Form extends Mage
                 'options'   => $apikeys,
                 )
             );
+
             $getStoresUrl = Mage::helper('adminhtml')->getUrl('adminhtml/mailchimpstores/getstores');
             $apikeyField->setAfterElementHtml("<script>var GET_STORES_URL = '".$getStoresUrl."';</script>");
 

--- a/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
@@ -4879,12 +4879,13 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
 
     /**
      * @param $str
+     * @param string $prefix
      * @return string
      */
-    public function mask($str)
+    public function mask($str, $prefix = '')
     {
-        return substr($str, 0, 6)
-            . str_repeat('*', strlen($str) - 4)
+        return $prefix . substr($str, 0, 6)
+            . str_repeat('*', strlen($str) - 4 - strlen($prefix))
             . substr($str, -4);
     }
 
@@ -5004,5 +5005,23 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
     public function unserialize($serialized, array $options = array())
     {
         return Zend_Serializer::unserialize($serialized, $options);
+    }
+
+    /**
+     * Check if Mailchimp API is available
+     *
+     * @param  $storeId
+     * @return boolean
+     */
+    public function ping($storeId)
+    {
+        try {
+            $api = $this->getApi($storeId);
+            $api->getRoot()->info();
+        } catch (Exception $e) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
@@ -209,10 +209,12 @@ class Ebizmarts_MailChimp_Model_Api_Batches
         $helper = $this->getHelper();
         $stores = $this->getStores();
         $helper->handleResendDataBefore();
+
         foreach ($stores as $store) {
             $storeId = $store->getId();
+
             if ($helper->isEcomSyncDataEnabled($storeId)) {
-                if ($this->_ping($storeId)) {
+                if ($helper->ping($storeId)) {
                     $this->_getResults($storeId);
                     $this->_sendEcommerceBatch($storeId);
                 } else {
@@ -226,33 +228,14 @@ class Ebizmarts_MailChimp_Model_Api_Batches
         }
 
         $helper->handleResendDataAfter();
-
         $syncedDateArray = array();
+
         foreach ($stores as $store) {
             $storeId = $store->getId();
             $syncedDateArray = $this->addSyncValueToArray($storeId, $syncedDateArray);
         }
 
         $this->handleSyncingValue($syncedDateArray);
-    }
-
-    /**
-     * Check if Mailchimp API is available
-     *
-     * @param  $storeId
-     * @return boolean
-     */
-    protected function _ping($storeId)
-    {
-        $helper = $this->getHelper();
-        try {
-            $api = $helper->getApi($storeId);
-            $api->root->info();
-        } catch (Exception $e) {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Helper/DataTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Helper/DataTest.php
@@ -1986,16 +1986,16 @@ class Ebizmarts_MailChimp_Helper_DataTest extends PHPUnit_Framework_TestCase
         );
 
         $ebizmartsMailchimpMock = $this->getMockBuilder(Ebizmarts_MailChimp::class)
-                ->disableOriginalConstructor()->setMethods(array('getLists'))
-                ->getMock();
+            ->disableOriginalConstructor()->setMethods(array('getLists'))
+            ->getMock();
 
         $mailchimpListsMock = $this->getMockBuilder(MailChimp_Lists::class)
-                ->disableOriginalConstructor()->setMethods(array('getMergeFields'))
-                ->getMock();
+            ->disableOriginalConstructor()->setMethods(array('getMergeFields'))
+            ->getMock();
 
         $mailchimpListsMergeFieldsMock = $this->getMockBuilder(MailChimp_ListsMergeFields::class)
-                ->disableOriginalConstructor()->setMethods(array('getAll'))
-                ->getMock();
+            ->disableOriginalConstructor()->setMethods(array('getAll'))
+            ->getMock();
 
         $helperDataMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
             ->disableOriginalConstructor()
@@ -2023,10 +2023,10 @@ class Ebizmarts_MailChimp_Helper_DataTest extends PHPUnit_Framework_TestCase
             ->willReturn($ebizmartsMailchimpMock);
 
         $ebizmartsMailchimpMock->expects($this->once())->method('getLists')
-        ->willReturn($mailchimpListsMock);
+            ->willReturn($mailchimpListsMock);
 
         $mailchimpListsMock->expects($this->once())->method('getMergeFields')
-        ->willReturn($mailchimpListsMergeFieldsMock);
+            ->willReturn($mailchimpListsMergeFieldsMock);
 
         $mailchimpListsMergeFieldsMock->expects($this->once())->method('getAll')
             ->with($listId, null, null, 50)
@@ -2078,5 +2078,33 @@ class Ebizmarts_MailChimp_Helper_DataTest extends PHPUnit_Framework_TestCase
             ->willReturn($mapFieldsUnserialized);
 
         $helperDataMock->getCustomMergeFields($scopeId, $scope);
+    }
+
+    public function testping()
+    {
+        $storeId = 6;
+
+        $helperDataMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getApi'))
+            ->getMock();
+
+        $apiMock = $this->getMockBuilder(Ebizmarts_MailChimp::class)
+            ->disableOriginalConstructor()->setMethods(array('getRoot'))
+            ->getMock();
+
+        $helperDataMock->expects($this->once())->method('getApi')->with($storeId)
+            ->willReturn($apiMock);
+
+        $apiRootMock = $this->getMockBuilder(MailChimp_Root::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('info'))
+            ->getMock();
+
+        $apiMock->expects($this->once())->method('getRoot')->willReturn($apiRootMock);
+
+        $apiRootMock->expects($this->once())->method('info');
+
+        $helperDataMock->ping($storeId);
     }
 }

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/BatchesTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/BatchesTest.php
@@ -258,15 +258,14 @@ class Ebizmarts_MailChimp_Model_Api_BatchesTest extends PHPUnit_Framework_TestCa
                     '_sendEcommerceBatch',
                     'addSyncValueToArray',
                     'handleSyncingValue',
-                    'getStores',
-                    '_ping'
+                    'getStores'
                 )
             )
             ->getMock();
 
         $helperMock = $this->getMockBuilder(Ebizmarts_MailChimp_Helper_Data::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('handleResendDataBefore', 'handleResendDataAfter', 'isEcomSyncDataEnabled'))
+            ->setMethods(array('handleResendDataBefore', 'handleResendDataAfter', 'isEcomSyncDataEnabled', 'ping'))
             ->getMock();
 
         $storeArrayMock = $this->getMockBuilder(Mage_Core_Model_Resource_Store_Collection::class)
@@ -305,7 +304,7 @@ class Ebizmarts_MailChimp_Model_Api_BatchesTest extends PHPUnit_Framework_TestCa
             ->method('addSyncValueToArray')
             ->with($storeId, $syncedArray)
             ->willReturn($syncedArray);
-        $apiBatchesMock->expects($this->once())->method('_ping')->with($storeId)->willReturn($apiStatus);
+        $helperMock->expects($this->once())->method('ping')->with($storeId)->willReturn($apiStatus);
 
         $apiBatchesMock->handleEcommerceBatches();
     }

--- a/js/ebizmarts/mailchimp/editstores.js
+++ b/js/ebizmarts/mailchimp/editstores.js
@@ -1,38 +1,59 @@
+function setRedColorInvalidAPIkey()
+{
+    var apiKeySelect = $('apikey');
+    var text = apiKeySelect[apiKeySelect.selectedIndex].text;
+
+    if(text.startsWith("[Invalid]")) {
+        apiKeySelect.style.color = 'red';
+    }
+    else{
+        apiKeySelect.style.color = 'black';
+    }
+}
+
 function loadStores()
 {
     var apiKey = $('apikey').value;
+
     $("listid").select('option').each(
         function (i) {
             i.remove();
         }
     );
+
     new Ajax.Request(
         GET_STORES_URL, {
             method: 'get',
-            parameters: {api_key:apiKey},
+            parameters: {api_key: apiKey},
             onComplete: function (transport) {
                 var json = transport.responseText.evalJSON();
-                $H(json).each(
-                    function (item) {
-                        option = new Option(item.value.name,item.value.id);
-                        $("listid").options.add(option);
-                    }
-                );
+
+                if (!json.error) {
+                    $H(json).each(
+                        function (item) {
+                            option = new Option(item.value.name, item.value.id);
+                            $("listid").options.add(option);
+                        }
+                    );
+                }
             }
         }
     );
+    setRedColorInvalidAPIkey();
 }
 
 function loadApiKeys()
 {
-    if ($('apikey')!= undefined && $('apikey').offsetWidth > 0 && $('apikey').offsetHeight > 0) {
+    let $apikey = $('apikey');
+
+    if ($apikey != undefined && $apikey.offsetWidth > 0 && $apikey.offsetHeight > 0) {
         loadStores();
-        $("apikey").onchange = loadStores;
+        $apikey.onchange = loadStores;
     }
 }
 
 if (document.loaded) {
-    loadApiKeys;
+    loadApiKeys();
 } else {
     document.observe('dom:loaded', loadApiKeys);
 }


### PR DESCRIPTION
Adding a prefix: "[Invalid]: " to the apikeys which are not valid in the combobox acting as API key selector.
Modifying mask($str, $prefix = '') method in Data.php in order to pass the prefix as param.
Deleting protected method: _ping($storeId) from Batches.php.
editstores.js: Making possible to change the API key color to red when it's invalid at the moment of store creation.
Adding new method (testping()) to DataTest.php
Modifying testHandleEcommerceBatches() method in BatchesTest.php
closes #1045 