### PR TITLE
Merge field limited to 30.

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/controllers/Adminhtml/EcommerceController.php
+++ b/app/code/community/Ebizmarts/MailChimp/controllers/Adminhtml/EcommerceController.php
@@ -87,8 +87,7 @@ class Ebizmarts_MailChimp_Adminhtml_EcommerceController extends Mage_Adminhtml_C
         $subEnabled = $helper->isSubscriptionEnabled($scopeId, $scope);
         if ($subEnabled) {
             try {
-                $helper->createMergeFields($scopeId, $scope);
-                $success = 1;
+                $success = $helper->createMergeFields($scopeId, $scope);
             } catch (MailChimp_Error $e) {
                 $helper->logError($e->getFriendlyMessage());
             } catch (Exception $e) {

--- a/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/system/config/createmergefields.phtml
+++ b/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/system/config/createmergefields.phtml
@@ -7,6 +7,9 @@
                 if (transport.responseText == 1) {
                     alert('The merge fields were successfully created.')
                 }
+                else if (transport.responseText == 2) {
+                    alert('Max. merge fields reached. \nOnly up to 30 merge fields are allowed.');
+                }
                 else {
                     alert('<?php echo $this->escapeHtml($this->getMessageForMailchimpErrorLog()) ?>')
                 }

--- a/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/system/config/form/field/array_dropdown.phtml
+++ b/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/system/config/form/field/array_dropdown.phtml
@@ -112,42 +112,50 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
         rowsCount : 0,
         add : function(templateData, insertAfterId)
         {
-            // generate default template data
-            if ('' == templateData) {
-                var d = new Date();
-                templateData = {
+            if (this.rowsCount >= 30) {
+                alert('Max. merge fields reached. \nOnly up to 30 merge fields are allowed.');
+            } else {
+                // generate default template data
+                if ('' == templateData) {
+                    var d = new Date();
+                    templateData = {
+                    <?php foreach ($this->_columns as $columnName => $column):?>
+                    <?php echo $this->quoteEscape($columnName) ?> :
+                    '',
+                    <?php endforeach;?>
+                        _id
+                :
+                    '_' + d.getTime() + '_' + d.getMilliseconds()
+                }
+                    ;
+                }
+                // insert before last row
+                if ('' == insertAfterId) {
+                    Element.insert(
+                        $('addRow<?php echo $this->quoteEscape($htmlId) ?>'),
+                        {before: this.template.evaluate(templateData)});
+                }
+                // insert after specified row
+                else {
+                    Element.insert($(insertAfterId), {after: this.template.evaluate(templateData)});
+                }
+                // set the selected drop-down list item
                 <?php foreach ($this->_columns as $columnName => $column):?>
-                    <?php echo $this->quoteEscape($columnName) ?> : '',
+                <?php if($columnName == 'magento'):?>
+                $$('select[name*=' + templateData._id + ']').each(function (row) {
+                    var oldText = 'value="' + templateData.<?php echo $this->quoteEscape($columnName) ?>+ '"';
+                    var newText = 'selected="selected" value="'
+                        + templateData.<?php echo $this->quoteEscape($columnName) ?>
+                        + '"';
+                    row.innerHTML = row.innerHTML.replace(oldText, newText);
+                });
+                <?php endif; ?>
                 <?php endforeach;?>
-                    _id : '_' + d.getTime() + '_' + d.getMilliseconds()
-            };
+                <?php if ($this->_addAfter):?>
+                Event.observe('addAfterBtn' + templateData._id, 'click', this.add.bind(this, '', templateData._id));
+                <?php endif;?>
+                this.rowsCount += 1;
             }
-            // insert before last row
-            if ('' == insertAfterId) {
-                Element.insert(
-                    $('addRow<?php echo $this->quoteEscape($htmlId) ?>'),
-                    {before: this.template.evaluate(templateData)});
-            }
-            // insert after specified row
-            else {
-                Element.insert($(insertAfterId), {after: this.template.evaluate(templateData)});
-            }
-            // set the selected drop-down list item
-            <?php foreach ($this->_columns as $columnName => $column):?>
-            <?php if($columnName == 'magento'):?>
-            $$('select[name*=' + templateData._id +']').each(function(row){
-                var oldText = 'value="'+templateData.<?php echo $this->quoteEscape($columnName) ?>+'"';
-                var newText = 'selected="selected" value="'
-                    +templateData.<?php echo $this->quoteEscape($columnName) ?>
-                    +'"';
-                row.innerHTML = row.innerHTML.replace(oldText,newText);
-            });
-            <?php endif; ?>
-            <?php endforeach;?>
-            <?php if ($this->_addAfter):?>
-            Event.observe('addAfterBtn' + templateData._id, 'click', this.add.bind(this, '', templateData._id));
-            <?php endif;?>
-            this.rowsCount += 1;
         },
         open: function () {
             var url = '<?php echo $this->escapeUrl($this->getUrl("adminhtml/mergevars/addmergevar/")) ?>?';


### PR DESCRIPTION
Ref. #957 .
Mailchimp does not synchronize more than 30 merge fields; this change limits the allowed merge fields in Magento's configuration to avoid creating more merge fields than would get synched.