### PR TITLE
Renaming $saveOnlyIfexists variable to $saveOnlyIfExists.

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
@@ -960,7 +960,7 @@ class Ebizmarts_MailChimp_Model_Api_Batches
         $syncDeleted = null,
         $token = null,
         $syncedFlag = null,
-        $saveOnlyIfexists = false
+        $saveOnlyIfExists = false
     ) {
         $helper = $this->getHelper();
         if ($itemType == Ebizmarts_MailChimp_Model_Config::IS_SUBSCRIBER) {


### PR DESCRIPTION
Renaming $saveOnlyIfexists variable to $saveOnlyIfExists, due to wrong reference inside of method.