### PR TITLE
Added possibility to send empty params

### DIFF
--- a/lib/Ebizmarts/MailChimp/ListsSegments.php
+++ b/lib/Ebizmarts/MailChimp/ListsSegments.php
@@ -126,11 +126,11 @@ class MailChimp_ListsSegments extends MailChimp_Abstract
     {
         $_params = array('name'=>$name);
 
-        if ($staticSegment) {
+        if (null !== $staticSegment) {
             $_params['static_segment'] = $staticSegment;
         }
 
-        if ($options) {
+        if (null !== $options) {
             $_params['options'] = $options;
         }
 


### PR DESCRIPTION
According to the developer documentation (https://mailchimp.com/developer/reference/lists/list-segments/) you should be allowed to send an empty static_segment but the value checker in the code does not allow the same condition. By just checking of the value is not null the developer can send in empty arrays.