### PR TITLE
Registering the product id if its type is not supported on Mailchimp.

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Products.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Products.php
@@ -554,7 +554,7 @@ class Ebizmarts_MailChimp_Model_Api_Products extends Ebizmarts_MailChimp_Model_A
                     $this->addSyncDataError(
                         $productId,
                         $mailchimpStoreId,
-                        "This product type is not supported on MailChimp.",
+                        "This product type is not supported on MailChimp. (product id: $productId)",
                         null,
                         null,
                         $dateHelper->formatDate(null, 'Y-m-d H:i:s')

--- a/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/ProductsTest.php
+++ b/dev/tests/mailchimp/tests/app/Ebizmarts/MailChimp/Model/Api/ProductsTest.php
@@ -384,6 +384,7 @@ class Ebizmarts_MailChimp_Model_Api_ProductsTest extends PHPUnit_Framework_TestC
         $itemTwoSyncDelta = '2018-03-14 15:03:35';
         $isProductEnabled = false;
         $error = "This product type is not supported on MailChimp.";
+        $error = "This product type is not supported on MailChimp. (product id: $groupedProductId)";
 
         $productsApiMock = $this->_productsApiMock
             ->setMethods(


### PR DESCRIPTION
Registering the product id in **mailchimp_sync_error** column of **mailchimp_ecommerce_sync_data** table, as part of the error message, if is not supported on Mailchimp.