### PR TITLE
Replaced quoteEscape for mcEscapeQuote method

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Customer/Edit/Tab/Mailchimp.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Customer/Edit/Tab/Mailchimp.php
@@ -51,6 +51,10 @@ class Ebizmarts_MailChimp_Block_Adminhtml_Customer_Edit_Tab_Mailchimp extends Ma
         return $interest;
     }
 
+    /**
+     * @param $data
+     * @return string
+     */
     public function escapeQuote($data)
     {
         return $this->getHelper()->mcEscapeQuote($data);

--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Customer/Edit/Tab/Mailchimp.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Customer/Edit/Tab/Mailchimp.php
@@ -51,6 +51,11 @@ class Ebizmarts_MailChimp_Block_Adminhtml_Customer_Edit_Tab_Mailchimp extends Ma
         return $interest;
     }
 
+    public function escapeQuote($data)
+    {
+        return $this->getHelper()->mcEscapeQuote($data);
+    }
+
     /**
      * @return Ebizmarts_MailChimp_Helper_Data
      */

--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Customer/Edit/Tab/Mailchimp.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Customer/Edit/Tab/Mailchimp.php
@@ -52,6 +52,14 @@ class Ebizmarts_MailChimp_Block_Adminhtml_Customer_Edit_Tab_Mailchimp extends Ma
     }
 
     /**
+     * @return Ebizmarts_MailChimp_Helper_Data
+     */
+    public function getHelper()
+    {
+        return $this->_helper;
+    }
+
+    /**
      * @return Mage_Newsletter_Model_Subscriber
      */
     protected function getSubscriberModel()

--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Sales/Order/View/Info/Monkey.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Sales/Order/View/Info/Monkey.php
@@ -69,7 +69,7 @@ class Ebizmarts_MailChimp_Block_Adminhtml_Sales_Order_View_Info_Monkey extends M
     /**
      * @return Ebizmarts_MailChimp_Helper_Data
      */
-    protected function getMailChimpHelper()
+    public function getMailChimpHelper()
     {
         return Mage::helper('mailchimp');
     }

--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Sales/Order/View/Info/Monkey.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Sales/Order/View/Info/Monkey.php
@@ -66,6 +66,10 @@ class Ebizmarts_MailChimp_Block_Adminhtml_Sales_Order_View_Info_Monkey extends M
         return $this->_campaignName;
     }
 
+    /**
+     * @param $data
+     * @return string
+     */
     public function escapeQuote($data)
     {
         return $this->getMailChimpHelper()->mcEscapeQuote($data);

--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Sales/Order/View/Info/Monkey.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/Sales/Order/View/Info/Monkey.php
@@ -66,6 +66,11 @@ class Ebizmarts_MailChimp_Block_Adminhtml_Sales_Order_View_Info_Monkey extends M
         return $this->_campaignName;
     }
 
+    public function escapeQuote($data)
+    {
+        return $this->getMailChimpHelper()->mcEscapeQuote($data);
+    }
+
     /**
      * @return Ebizmarts_MailChimp_Helper_Data
      */

--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/System/Config/Form/Field/Mapfields.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/System/Config/Form/Field/Mapfields.php
@@ -69,10 +69,15 @@ class Ebizmarts_MailChimp_Block_Adminhtml_System_Config_Form_Field_Mapfields
         ksort($this->_customerAttributes);
     }
 
+    public function escapeQuote($data)
+    {
+        return $this->getHelper()->mcEscapeQuote($data);
+    }
+
     /**
      * @return Ebizmarts_MailChimp_Helper_Data
      */
-    public function getHelper()
+    protected function getHelper()
     {
         return $this->_helper;
     }

--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/System/Config/Form/Field/Mapfields.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/System/Config/Form/Field/Mapfields.php
@@ -77,7 +77,7 @@ class Ebizmarts_MailChimp_Block_Adminhtml_System_Config_Form_Field_Mapfields
     /**
      * @return Ebizmarts_MailChimp_Helper_Data
      */
-    protected function getHelper()
+    public function getHelper()
     {
         return $this->_helper;
     }

--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/System/Config/Form/Field/Mapfields.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/System/Config/Form/Field/Mapfields.php
@@ -70,6 +70,14 @@ class Ebizmarts_MailChimp_Block_Adminhtml_System_Config_Form_Field_Mapfields
     }
 
     /**
+     * @return Ebizmarts_MailChimp_Helper_Data
+     */
+    public function getHelper()
+    {
+        return $this->_helper;
+    }
+
+    /**
      * @param string $columnName
      * @return string
      */

--- a/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/System/Config/Form/Field/Mapfields.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Adminhtml/System/Config/Form/Field/Mapfields.php
@@ -69,6 +69,10 @@ class Ebizmarts_MailChimp_Block_Adminhtml_System_Config_Form_Field_Mapfields
         ksort($this->_customerAttributes);
     }
 
+    /**
+     * @param $data
+     * @return string
+     */
     public function escapeQuote($data)
     {
         return $this->getHelper()->mcEscapeQuote($data);

--- a/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Subscribe.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Subscribe.php
@@ -38,7 +38,7 @@ class Ebizmarts_MailChimp_Block_Checkout_Subscribe extends Mage_Core_Block_Templ
     /**
      * @return Ebizmarts_MailChimp_Helper_Data
      */
-    protected function getHelper()
+    public function getHelper()
     {
         return $this->_helper;
     }

--- a/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Subscribe.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Subscribe.php
@@ -30,10 +30,15 @@ class Ebizmarts_MailChimp_Block_Checkout_Subscribe extends Mage_Core_Block_Templ
         $this->_storeId = Mage::app()->getStore()->getId();
     }
 
+    public function escapeQuote($data)
+    {
+        return $this->getHelper()->mcEscapeQuote($data);
+    }
+
     /**
      * @return Ebizmarts_MailChimp_Helper_Data
      */
-    public function getHelper()
+    protected function getHelper()
     {
         return $this->_helper;
     }

--- a/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Subscribe.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Subscribe.php
@@ -30,6 +30,10 @@ class Ebizmarts_MailChimp_Block_Checkout_Subscribe extends Mage_Core_Block_Templ
         $this->_storeId = Mage::app()->getStore()->getId();
     }
 
+    /**
+     * @param $data
+     * @return string
+     */
     public function escapeQuote($data)
     {
         return $this->getHelper()->mcEscapeQuote($data);

--- a/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Subscribe.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Subscribe.php
@@ -31,6 +31,14 @@ class Ebizmarts_MailChimp_Block_Checkout_Subscribe extends Mage_Core_Block_Templ
     }
 
     /**
+     * @return Ebizmarts_MailChimp_Helper_Data
+     */
+    public function getHelper()
+    {
+        return $this->_helper;
+    }
+
+    /**
      * Render block HTML
      *
      * @return string

--- a/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Success/Groups.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Success/Groups.php
@@ -82,6 +82,14 @@ class Ebizmarts_MailChimp_Block_Checkout_Success_Groups extends Mage_Core_Block_
     }
 
     /**
+     * @return Ebizmarts_MailChimp_Helper_Data|Mage_Core_Helper_Abstract
+     */
+    public function getMailChimpHelper()
+    {
+        return $this->_helper;
+    }
+
+    /**
      * @return false|Mage_Core_Model_Abstract
      */
     protected function getSubscriberModel()
@@ -100,13 +108,5 @@ class Ebizmarts_MailChimp_Block_Checkout_Success_Groups extends Mage_Core_Block_
     protected function getSessionLastRealOrder()
     {
         return $this->getMailChimpHelper()->getSessionLastRealOrder();
-    }
-
-    /**
-     * @return Ebizmarts_MailChimp_Helper_Data|Mage_Core_Helper_Abstract
-     */
-    protected function getMailChimpHelper()
-    {
-        return $this->_helper;
     }
 }

--- a/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Success/Groups.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Success/Groups.php
@@ -81,6 +81,10 @@ class Ebizmarts_MailChimp_Block_Checkout_Success_Groups extends Mage_Core_Block_
         return $message;
     }
 
+    /**
+     * @param $data
+     * @return string
+     */
     public function escapeQuote($data)
     {
         return $this->getMailChimpHelper()->mcEscapeQuote($data);

--- a/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Success/Groups.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Success/Groups.php
@@ -89,7 +89,7 @@ class Ebizmarts_MailChimp_Block_Checkout_Success_Groups extends Mage_Core_Block_
     /**
      * @return Ebizmarts_MailChimp_Helper_Data|Mage_Core_Helper_Abstract
      */
-    protected function getMailChimpHelper()
+    public function getMailChimpHelper()
     {
         return $this->_helper;
     }

--- a/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Success/Groups.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Checkout/Success/Groups.php
@@ -81,10 +81,15 @@ class Ebizmarts_MailChimp_Block_Checkout_Success_Groups extends Mage_Core_Block_
         return $message;
     }
 
+    public function escapeQuote($data)
+    {
+        return $this->getMailChimpHelper()->mcEscapeQuote($data);
+    }
+
     /**
      * @return Ebizmarts_MailChimp_Helper_Data|Mage_Core_Helper_Abstract
      */
-    public function getMailChimpHelper()
+    protected function getMailChimpHelper()
     {
         return $this->_helper;
     }

--- a/app/code/community/Ebizmarts/MailChimp/Block/Customer/Newsletter/Index.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Customer/Newsletter/Index.php
@@ -56,10 +56,15 @@ class Ebizmarts_MailChimp_Block_Customer_Newsletter_Index extends Mage_Customer_
         return $interest;
     }
 
+    public function escapeQuote($data)
+    {
+        return $this->getMailChimpHelper()->mcEscapeQuote($data);
+    }
+
     /**
      * @return Ebizmarts_MailChimp_Helper_Data
      */
-    public function getMailChimpHelper()
+    protected function getMailChimpHelper()
     {
         return $this->_helper;
     }

--- a/app/code/community/Ebizmarts/MailChimp/Block/Customer/Newsletter/Index.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Customer/Newsletter/Index.php
@@ -64,7 +64,7 @@ class Ebizmarts_MailChimp_Block_Customer_Newsletter_Index extends Mage_Customer_
     /**
      * @return Ebizmarts_MailChimp_Helper_Data
      */
-    protected function getMailChimpHelper()
+    public function getMailChimpHelper()
     {
         return $this->_helper;
     }

--- a/app/code/community/Ebizmarts/MailChimp/Block/Customer/Newsletter/Index.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Customer/Newsletter/Index.php
@@ -56,6 +56,10 @@ class Ebizmarts_MailChimp_Block_Customer_Newsletter_Index extends Mage_Customer_
         return $interest;
     }
 
+    /**
+     * @param $data
+     * @return string
+     */
     public function escapeQuote($data)
     {
         return $this->getMailChimpHelper()->mcEscapeQuote($data);

--- a/app/code/community/Ebizmarts/MailChimp/Block/Customer/Newsletter/Index.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Customer/Newsletter/Index.php
@@ -57,6 +57,14 @@ class Ebizmarts_MailChimp_Block_Customer_Newsletter_Index extends Mage_Customer_
     }
 
     /**
+     * @return Ebizmarts_MailChimp_Helper_Data
+     */
+    public function getMailChimpHelper()
+    {
+        return $this->_helper;
+    }
+
+    /**
      * Retrieve email from Customer object in session
      *
      * @return string Email address
@@ -64,14 +72,6 @@ class Ebizmarts_MailChimp_Block_Customer_Newsletter_Index extends Mage_Customer_
     protected function _getEmail()
     {
         return $this->getCustomerSession()->getCustomer()->getEmail();
-    }
-
-    /**
-     * @return Ebizmarts_MailChimp_Helper_Data
-     */
-    protected function getMailChimpHelper()
-    {
-        return $this->_helper;
     }
 
     /**

--- a/app/code/community/Ebizmarts/MailChimp/Block/Group/Type.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Group/Type.php
@@ -11,9 +11,12 @@
 class Ebizmarts_MailChimp_Block_Group_Type extends Mage_Core_Block_Template
 {
     protected $_currentInterest;
+    protected $_helper;
 
     public function __construct(array $args = array())
     {
+        $this->_helper = Mage::helper('mailchimp');
+
         if (isset($args['interests'])) {
             $this->_currentInterest = $interests = $args['interests'];
             $type = $interests['interest']['type'];
@@ -21,6 +24,14 @@ class Ebizmarts_MailChimp_Block_Group_Type extends Mage_Core_Block_Template
         }
 
         parent::__construct($args);
+    }
+
+    /**
+     * @return Ebizmarts_MailChimp_Helper_Data
+     */
+    public function getHelper()
+    {
+        return $this->_helper;
     }
 
     /**

--- a/app/code/community/Ebizmarts/MailChimp/Block/Group/Type.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Group/Type.php
@@ -26,6 +26,10 @@ class Ebizmarts_MailChimp_Block_Group_Type extends Mage_Core_Block_Template
         parent::__construct($args);
     }
 
+    /**
+     * @param $data
+     * @return string
+     */
     public function escapeQuote($data)
     {
         return $this->getHelper()->mcEscapeQuote($data);

--- a/app/code/community/Ebizmarts/MailChimp/Block/Group/Type.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Group/Type.php
@@ -34,7 +34,7 @@ class Ebizmarts_MailChimp_Block_Group_Type extends Mage_Core_Block_Template
     /**
      * @return Ebizmarts_MailChimp_Helper_Data
      */
-    protected function getHelper()
+    public function getHelper()
     {
         return $this->_helper;
     }

--- a/app/code/community/Ebizmarts/MailChimp/Block/Group/Type.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Group/Type.php
@@ -26,10 +26,15 @@ class Ebizmarts_MailChimp_Block_Group_Type extends Mage_Core_Block_Template
         parent::__construct($args);
     }
 
+    public function escapeQuote($data)
+    {
+        return $this->getHelper()->mcEscapeQuote($data);
+    }
+
     /**
      * @return Ebizmarts_MailChimp_Helper_Data
      */
-    public function getHelper()
+    protected function getHelper()
     {
         return $this->_helper;
     }

--- a/app/code/community/Ebizmarts/MailChimp/Block/Popup/Emailcatcher.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Popup/Emailcatcher.php
@@ -12,6 +12,10 @@
  */
 class Ebizmarts_MailChimp_Block_Popup_Emailcatcher extends Mage_Core_Block_Template
 {
+    /**
+     * @param $data
+     * @return string
+     */
     public function escapeQuote($data)
     {
         return $this->getHelper()->mcEscapeQuote($data);

--- a/app/code/community/Ebizmarts/MailChimp/Block/Popup/Emailcatcher.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Popup/Emailcatcher.php
@@ -12,6 +12,11 @@
  */
 class Ebizmarts_MailChimp_Block_Popup_Emailcatcher extends Mage_Core_Block_Template
 {
+    public function escapeQuote($data)
+    {
+        return $this->getHelper()->mcEscapeQuote($data);
+    }
+
     /**
      * @return Ebizmarts_MailChimp_Helper_Data
      */

--- a/app/code/community/Ebizmarts/MailChimp/Block/Popup/Emailcatcher.php
+++ b/app/code/community/Ebizmarts/MailChimp/Block/Popup/Emailcatcher.php
@@ -12,6 +12,13 @@
  */
 class Ebizmarts_MailChimp_Block_Popup_Emailcatcher extends Mage_Core_Block_Template
 {
+    /**
+     * @return Ebizmarts_MailChimp_Helper_Data
+     */
+    public function getHelper()
+    {
+        return Mage::helper('mailchimp');
+    }
 
     protected function _canCancel()
     {

--- a/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MailChimp/Helper/Data.php
@@ -1175,6 +1175,15 @@ class Ebizmarts_MailChimp_Helper_Data extends Mage_Core_Helper_Abstract
     }
 
     /**
+     * @param $data
+     * @return string
+     */
+    public function mcEscapeQuote($data)
+    {
+        return htmlspecialchars($data, ENT_QUOTES, null, false);
+    }
+
+    /**
      * @param $scopeId
      * @param $scope
      * @return int

--- a/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/customer/tab/mailchimp.phtml
+++ b/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/customer/tab/mailchimp.phtml
@@ -4,7 +4,7 @@ $interest = $this->getInterest();
 <div class="fieldset-wrapper">
     <div class="fieldset-wrapper-title">
         <span class="title">
-            <?php /* @escapeNotVerified */ echo $this->gethelper()->mcEscapeQuote($this->__('Mailchimp Information')) ?>
+            <?php /* @escapeNotVerified */ echo $this->escapeQuote($this->__('Mailchimp Information')) ?>
         </span>
     </div>
     <div class="admin__fieldset-wrapper-content">

--- a/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/customer/tab/mailchimp.phtml
+++ b/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/customer/tab/mailchimp.phtml
@@ -4,7 +4,7 @@ $interest = $this->getInterest();
 <div class="fieldset-wrapper">
     <div class="fieldset-wrapper-title">
         <span class="title">
-            <?php /* @escapeNotVerified */ echo $this->quoteEscape($this->__('Mailchimp Information')) ?>
+            <?php /* @escapeNotVerified */ echo $this->gethelper()->mcEscapeQuote($this->__('Mailchimp Information')) ?>
         </span>
     </div>
     <div class="admin__fieldset-wrapper-content">

--- a/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/sales/order/view/monkey.phtml
+++ b/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/sales/order/view/monkey.phtml
@@ -1,7 +1,7 @@
 <?php if($this->isReferred()) : ?>
 <div class="entry-edit box-right">
     <div class="entry-edit-head">
-        <h4 class="icon-head"><?php echo $this->quoteEscape($this->__('MailChimp')) ?></h4>
+        <h4 class="icon-head"><?php echo $this->getMailChimpHelper()->mcEscapeQuote($this->__('MailChimp')) ?></h4>
     </div>
     <fieldset>
         <div id="mailchimp_monkey">
@@ -16,7 +16,7 @@
                     </td>
                     <td class="value">
                         <?php if ($this->isDataAvailable()): ?>
-                            <strong><?php echo $this->quoteEscape(
+                            <strong><?php echo $this->getMailChimpHelper()->mcEscapeQuote(
                                 $this->__("Yaay! Recovered by Mailchimp's campaign.") .
                                     "<br />" .
                                     $this->__("Name") .
@@ -27,7 +27,7 @@
                             ); ?>
                             </strong>
                         <?php else: ?>
-                            <strong><?php echo $this->quoteEscape(
+                            <strong><?php echo $this->getMailChimpHelper()->mcEscapeQuote(
                                 $this->__("The campaign does not belong to the audience configured for ") .
                                     $this->getStoreCodeFromOrder() .
                                 $this->__(" view.")

--- a/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/sales/order/view/monkey.phtml
+++ b/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/sales/order/view/monkey.phtml
@@ -1,7 +1,7 @@
 <?php if($this->isReferred()) : ?>
 <div class="entry-edit box-right">
     <div class="entry-edit-head">
-        <h4 class="icon-head"><?php echo $this->getMailChimpHelper()->mcEscapeQuote($this->__('MailChimp')) ?></h4>
+        <h4 class="icon-head"><?php echo $this->escapeQuote($this->__('MailChimp')) ?></h4>
     </div>
     <fieldset>
         <div id="mailchimp_monkey">
@@ -16,7 +16,7 @@
                     </td>
                     <td class="value">
                         <?php if ($this->isDataAvailable()): ?>
-                            <strong><?php echo $this->getMailChimpHelper()->mcEscapeQuote(
+                            <strong><?php echo $this->escapeQuote(
                                 $this->__("Yaay! Recovered by Mailchimp's campaign.") .
                                     "<br />" .
                                     $this->__("Name") .
@@ -27,7 +27,7 @@
                             ); ?>
                             </strong>
                         <?php else: ?>
-                            <strong><?php echo $this->getMailChimpHelper()->mcEscapeQuote(
+                            <strong><?php echo $this->escapeQuote(
                                 $this->__("The campaign does not belong to the audience configured for ") .
                                     $this->getStoreCodeFromOrder() .
                                 $this->__(" view.")

--- a/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/system/config/form/field/array_dropdown.phtml
+++ b/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/system/config/form/field/array_dropdown.phtml
@@ -14,28 +14,28 @@ if (!$this->_addAfter) {
 $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
 ?>
 
-<div class="grid" id="grid<?php echo $this->quoteEscape($htmlId) ?>">
+<div class="grid" id="grid<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
     <table cellpadding="0" cellspacing="0" class="border">
         <tbody>
 
-        <tr class="headings" id="headings<?php echo $this->quoteEscape($htmlId) ?>">
+        <tr class="headings" id="headings<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
             <?php foreach ($this->_columns as $columnName => $column): ?>
-                <th><?php echo $this->quoteEscape($column['label']) ?></th>
+                <th><?php echo $this->gethelper()->mcEscapeQuote($column['label']) ?></th>
             <?php endforeach; ?>
-            <th <?php echo $this->quoteEscape($colspan) ?>></th>
+            <th <?php echo $this->gethelper()->mcEscapeQuote($colspan) ?>></th>
         </tr>
 
-        <tr id="addRow<?php echo $this->quoteEscape($htmlId) ?>">
-            <td colspan="<?php echo $this->quoteEscape(count($this->_columns)) ?>">
+        <tr id="addRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
+            <td colspan="<?php echo $this->gethelper()->mcEscapeQuote(count($this->_columns)) ?>">
                 <button style=""
                         onclick=""
                         class="scalable add"
                         type="button"
-                        id="addNewType<?php echo $this->quoteEscape($htmlId) ?>">
+                        id="addNewType<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
                     <span>
                         <span>
                             <span>
-                                <?php echo $this->quoteEscape(
+                                <?php echo $this->gethelper()->mcEscapeQuote(
                                     Mage::helper('mailchimp')->__(
                                         'Add new custom data entry in the column of the right'
                                     )
@@ -45,16 +45,16 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
                     </span>
                 </button>
             </td>
-            <td <?php echo $this->quoteEscape($colspan) ?>>
+            <td <?php echo $this->gethelper()->mcEscapeQuote($colspan) ?>>
                 <button style=""
                         onclick=""
                         class="scalable add"
                         type="button"
-                        id="addToEndBtn<?php echo $this->quoteEscape($htmlId) ?>">
+                        id="addToEndBtn<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
                     <span>
                         <span>
                             <span>
-                                <?php echo $this->quoteEscape(Mage::helper('mailchimp')->__('Add new row')) ?>
+                                <?php echo $this->gethelper()->mcEscapeQuote(Mage::helper('mailchimp')->__('Add new row')) ?>
                             </span>
                         </span>
                     </span>
@@ -64,18 +64,18 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
 
         </tbody>
     </table>
-    <input type="hidden" name="<?php echo $this->quoteEscape($this->getElement()->getName()) ?>[__empty]" value=""/>
+    <input type="hidden" name="<?php echo $this->gethelper()->mcEscapeQuote($this->getElement()->getName()) ?>[__empty]" value=""/>
 </div>
-<div id="empty<?php echo $this->quoteEscape($htmlId) ?>">
+<div id="empty<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
     <button style=""
             onclick=""
             class="scalable add"
             type="button"
-            id="emptyAddBtn<?php echo $this->quoteEscape($htmlId) ?>">
+            id="emptyAddBtn<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
         <span>
             <span>
                 <span>
-                    <?php echo $this->quoteEscape($this->_addButtonLabel) ?>
+                    <?php echo $this->gethelper()->mcEscapeQuote($this->_addButtonLabel) ?>
                 </span>
             </span>
         </span>
@@ -84,7 +84,7 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
 
 <script type="text/javascript">
     // create row creator
-    var arrayRow<?php echo $this->quoteEscape($htmlId) ?> = {
+    var arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?> = {
         // define row prototypeJS template
         template: new Template(
             '<tr id="#{_id}">'
@@ -99,7 +99,7 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
             echo $this->jsQuoteEscape(Mage::helper('adminhtml')->__('Add after'))?>
             +'<\/span><\/span><\/span><\/button><\/td>'
             <?php endif;?>
-            + '<td><button onclick="arrayRow<?php echo $this->quoteEscape($htmlId) ?>.del(\'#{_id}\')" '
+            + '<td><button onclick="arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>.del(\'#{_id}\')" '
             + 'class="scalable delete" type="button"><span><span><span>'
             + '<?php echo $this->jsQuoteEscape(Mage::helper('adminhtml')->__('Delete')) ?>'
             + '<\/span><\/span><\/span><\/button><\/td>'
@@ -115,7 +115,7 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
                     var d = new Date();
                     templateData = {
                         <?php foreach ($this->_columns as $columnName => $column):?>
-                        <?php echo $this->quoteEscape($columnName) ?>: '',
+                        <?php echo $this->gethelper()->mcEscapeQuote($columnName) ?>: '',
                         <?php endforeach;?>
                         _id: '_' + d.getTime() + '_' + d.getMilliseconds()
                     };
@@ -123,7 +123,7 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
                 // insert before last row
                 if ('' == insertAfterId) {
                     Element.insert(
-                        $('addRow<?php echo $this->quoteEscape($htmlId) ?>'),
+                        $('addRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>'),
                         {before: this.template.evaluate(templateData)});
                 }
                 // insert after specified row
@@ -134,9 +134,9 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
                 <?php foreach ($this->_columns as $columnName => $column):?>
                 <?php if($columnName == 'magento'):?>
                 $$('select[name*=' + templateData._id + ']').each(function (row) {
-                    var oldText = 'value="' + templateData.<?php echo $this->quoteEscape($columnName) ?>+ '"';
+                    var oldText = 'value="' + templateData.<?php echo $this->gethelper()->mcEscapeQuote($columnName) ?>+ '"';
                     var newText = 'selected="selected" value="'
-                        + templateData.<?php echo $this->quoteEscape($columnName) ?>
+                        + templateData.<?php echo $this->gethelper()->mcEscapeQuote($columnName) ?>
                         + '"';
                     row.innerHTML = row.innerHTML.replace(oldText, newText);
                 });
@@ -179,48 +179,48 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
             }
         },
         showButtonOnly: function () {
-            $('grid<?php echo $this->quoteEscape($htmlId) ?>').hide();
-            $('empty<?php echo $this->quoteEscape($htmlId) ?>').show();
+            $('grid<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>').hide();
+            $('empty<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>').show();
         }
     };
     // bind add action to "Add" button in last row
     Event.observe(
-        'addToEndBtn<?php echo $this->quoteEscape($htmlId) ?>',
+        'addToEndBtn<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>',
         'click',
-        arrayRow<?php echo $this->quoteEscape($htmlId) ?>.add.bind(
-            arrayRow<?php echo $this->quoteEscape($htmlId) ?>,
+        arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>.add.bind(
+            arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>,
             '',
             ''
         )
     );
     Event.observe(
-        'addNewType<?php echo $this->quoteEscape($htmlId) ?>',
+        'addNewType<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>',
         'click',
-        arrayRow<?php echo $this->quoteEscape($htmlId) ?>.open.bind(this)
+        arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>.open.bind(this)
     );
     // add existing rows
     <?php
     $addAfterId = "headings{$htmlId}";
     foreach ($this->getArrayRows() as $rowId => $row) {
-        echo $this->quoteEscape("arrayRow{$htmlId}.add(")
+        echo $this->gethelper()->mcEscapeQuote("arrayRow{$htmlId}.add(")
             . $this->jsQuoteEscape($row->toJson())
             . $this->jsQuoteEscape(", {$addAfterId});\n");
         $addAfterId = $rowId;
     }
     ?>
     // initialize standalone button
-    $('empty<?php echo $this->quoteEscape($htmlId) ?>').hide();
-    Event.observe('emptyAddBtn<?php echo $this->quoteEscape($htmlId) ?>', 'click', function () {
-        $('grid<?php echo $this->quoteEscape($htmlId) ?>').show();
-        $('empty<?php echo $this->quoteEscape($htmlId) ?>').hide();
-        arrayRow<?php echo $this->quoteEscape($htmlId) ?>.add('', '');
+    $('empty<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>').hide();
+    Event.observe('emptyAddBtn<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>', 'click', function () {
+        $('grid<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>').show();
+        $('empty<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>').hide();
+        arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>.add('', '');
     });
     // if no rows, hide grid and show button only
     <?php if (!$this->getArrayRows()):?>
-    arrayRow<?php echo $this->quoteEscape($htmlId) ?>.showButtonOnly();
+    arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>.showButtonOnly();
     <?php endif;?>
     // toggle the grid, if element is disabled (depending on scope)
     <?php if ($this->getElement()->getDisabled()):?>
-    toggleValueElements({checked: true}, $('grid<?php echo $this->quoteEscape($htmlId) ?>').parentNode);
+    toggleValueElements({checked: true}, $('grid<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>').parentNode);
     <?php endif;?>
 </script>

--- a/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/system/config/form/field/array_dropdown.phtml
+++ b/app/design/adminhtml/default/default/template/ebizmarts/mailchimp/system/config/form/field/array_dropdown.phtml
@@ -14,28 +14,28 @@ if (!$this->_addAfter) {
 $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
 ?>
 
-<div class="grid" id="grid<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
+<div class="grid" id="grid<?php echo $this->escapeQuote($htmlId) ?>">
     <table cellpadding="0" cellspacing="0" class="border">
         <tbody>
 
-        <tr class="headings" id="headings<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
+        <tr class="headings" id="headings<?php echo $this->escapeQuote($htmlId) ?>">
             <?php foreach ($this->_columns as $columnName => $column): ?>
-                <th><?php echo $this->gethelper()->mcEscapeQuote($column['label']) ?></th>
+                <th><?php echo $this->escapeQuote($column['label']) ?></th>
             <?php endforeach; ?>
-            <th <?php echo $this->gethelper()->mcEscapeQuote($colspan) ?>></th>
+            <th <?php echo $this->escapeQuote($colspan) ?>></th>
         </tr>
 
-        <tr id="addRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
-            <td colspan="<?php echo $this->gethelper()->mcEscapeQuote(count($this->_columns)) ?>">
+        <tr id="addRow<?php echo $this->escapeQuote($htmlId) ?>">
+            <td colspan="<?php echo $this->escapeQuote(count($this->_columns)) ?>">
                 <button style=""
                         onclick=""
                         class="scalable add"
                         type="button"
-                        id="addNewType<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
+                        id="addNewType<?php echo $this->escapeQuote($htmlId) ?>">
                     <span>
                         <span>
                             <span>
-                                <?php echo $this->gethelper()->mcEscapeQuote(
+                                <?php echo $this->escapeQuote(
                                     Mage::helper('mailchimp')->__(
                                         'Add new custom data entry in the column of the right'
                                     )
@@ -45,16 +45,16 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
                     </span>
                 </button>
             </td>
-            <td <?php echo $this->gethelper()->mcEscapeQuote($colspan) ?>>
+            <td <?php echo $this->escapeQuote($colspan) ?>>
                 <button style=""
                         onclick=""
                         class="scalable add"
                         type="button"
-                        id="addToEndBtn<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
+                        id="addToEndBtn<?php echo $this->escapeQuote($htmlId) ?>">
                     <span>
                         <span>
                             <span>
-                                <?php echo $this->gethelper()->mcEscapeQuote(Mage::helper('mailchimp')->__('Add new row')) ?>
+                                <?php echo $this->escapeQuote(Mage::helper('mailchimp')->__('Add new row')) ?>
                             </span>
                         </span>
                     </span>
@@ -64,18 +64,18 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
 
         </tbody>
     </table>
-    <input type="hidden" name="<?php echo $this->gethelper()->mcEscapeQuote($this->getElement()->getName()) ?>[__empty]" value=""/>
+    <input type="hidden" name="<?php echo $this->escapeQuote($this->getElement()->getName()) ?>[__empty]" value=""/>
 </div>
-<div id="empty<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
+<div id="empty<?php echo $this->escapeQuote($htmlId) ?>">
     <button style=""
             onclick=""
             class="scalable add"
             type="button"
-            id="emptyAddBtn<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>">
+            id="emptyAddBtn<?php echo $this->escapeQuote($htmlId) ?>">
         <span>
             <span>
                 <span>
-                    <?php echo $this->gethelper()->mcEscapeQuote($this->_addButtonLabel) ?>
+                    <?php echo $this->escapeQuote($this->_addButtonLabel) ?>
                 </span>
             </span>
         </span>
@@ -84,7 +84,7 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
 
 <script type="text/javascript">
     // create row creator
-    var arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?> = {
+    var arrayRow<?php echo $this->escapeQuote($htmlId) ?> = {
         // define row prototypeJS template
         template: new Template(
             '<tr id="#{_id}">'
@@ -99,7 +99,7 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
             echo $this->jsQuoteEscape(Mage::helper('adminhtml')->__('Add after'))?>
             +'<\/span><\/span><\/span><\/button><\/td>'
             <?php endif;?>
-            + '<td><button onclick="arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>.del(\'#{_id}\')" '
+            + '<td><button onclick="arrayRow<?php echo $this->escapeQuote($htmlId) ?>.del(\'#{_id}\')" '
             + 'class="scalable delete" type="button"><span><span><span>'
             + '<?php echo $this->jsQuoteEscape(Mage::helper('adminhtml')->__('Delete')) ?>'
             + '<\/span><\/span><\/span><\/button><\/td>'
@@ -115,7 +115,7 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
                     var d = new Date();
                     templateData = {
                         <?php foreach ($this->_columns as $columnName => $column):?>
-                        <?php echo $this->gethelper()->mcEscapeQuote($columnName) ?>: '',
+                        <?php echo $this->escapeQuote($columnName) ?>: '',
                         <?php endforeach;?>
                         _id: '_' + d.getTime() + '_' + d.getMilliseconds()
                     };
@@ -123,7 +123,7 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
                 // insert before last row
                 if ('' == insertAfterId) {
                     Element.insert(
-                        $('addRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>'),
+                        $('addRow<?php echo $this->escapeQuote($htmlId) ?>'),
                         {before: this.template.evaluate(templateData)});
                 }
                 // insert after specified row
@@ -134,9 +134,9 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
                 <?php foreach ($this->_columns as $columnName => $column):?>
                 <?php if($columnName == 'magento'):?>
                 $$('select[name*=' + templateData._id + ']').each(function (row) {
-                    var oldText = 'value="' + templateData.<?php echo $this->gethelper()->mcEscapeQuote($columnName) ?>+ '"';
+                    var oldText = 'value="' + templateData.<?php echo $this->escapeQuote($columnName) ?>+ '"';
                     var newText = 'selected="selected" value="'
-                        + templateData.<?php echo $this->gethelper()->mcEscapeQuote($columnName) ?>
+                        + templateData.<?php echo $this->escapeQuote($columnName) ?>
                         + '"';
                     row.innerHTML = row.innerHTML.replace(oldText, newText);
                 });
@@ -179,48 +179,48 @@ $colspan = $colspan > 1 ? 'colspan="' . $colspan . '"' : '';
             }
         },
         showButtonOnly: function () {
-            $('grid<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>').hide();
-            $('empty<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>').show();
+            $('grid<?php echo $this->escapeQuote($htmlId) ?>').hide();
+            $('empty<?php echo $this->escapeQuote($htmlId) ?>').show();
         }
     };
     // bind add action to "Add" button in last row
     Event.observe(
-        'addToEndBtn<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>',
+        'addToEndBtn<?php echo $this->escapeQuote($htmlId) ?>',
         'click',
-        arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>.add.bind(
-            arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>,
+        arrayRow<?php echo $this->escapeQuote($htmlId) ?>.add.bind(
+            arrayRow<?php echo $this->escapeQuote($htmlId) ?>,
             '',
             ''
         )
     );
     Event.observe(
-        'addNewType<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>',
+        'addNewType<?php echo $this->escapeQuote($htmlId) ?>',
         'click',
-        arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>.open.bind(this)
+        arrayRow<?php echo $this->escapeQuote($htmlId) ?>.open.bind(this)
     );
     // add existing rows
     <?php
     $addAfterId = "headings{$htmlId}";
     foreach ($this->getArrayRows() as $rowId => $row) {
-        echo $this->gethelper()->mcEscapeQuote("arrayRow{$htmlId}.add(")
+        echo $this->escapeQuote("arrayRow{$htmlId}.add(")
             . $this->jsQuoteEscape($row->toJson())
             . $this->jsQuoteEscape(", {$addAfterId});\n");
         $addAfterId = $rowId;
     }
     ?>
     // initialize standalone button
-    $('empty<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>').hide();
-    Event.observe('emptyAddBtn<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>', 'click', function () {
-        $('grid<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>').show();
-        $('empty<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>').hide();
-        arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>.add('', '');
+    $('empty<?php echo $this->escapeQuote($htmlId) ?>').hide();
+    Event.observe('emptyAddBtn<?php echo $this->escapeQuote($htmlId) ?>', 'click', function () {
+        $('grid<?php echo $this->escapeQuote($htmlId) ?>').show();
+        $('empty<?php echo $this->escapeQuote($htmlId) ?>').hide();
+        arrayRow<?php echo $this->escapeQuote($htmlId) ?>.add('', '');
     });
     // if no rows, hide grid and show button only
     <?php if (!$this->getArrayRows()):?>
-    arrayRow<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>.showButtonOnly();
+    arrayRow<?php echo $this->escapeQuote($htmlId) ?>.showButtonOnly();
     <?php endif;?>
     // toggle the grid, if element is disabled (depending on scope)
     <?php if ($this->getElement()->getDisabled()):?>
-    toggleValueElements({checked: true}, $('grid<?php echo $this->gethelper()->mcEscapeQuote($htmlId) ?>').parentNode);
+    toggleValueElements({checked: true}, $('grid<?php echo $this->escapeQuote($htmlId) ?>').parentNode);
     <?php endif;?>
 </script>

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/checkout/subscribe.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/checkout/subscribe.phtml
@@ -66,7 +66,7 @@ $generalList = $this->getGeneralList();
 endif; ?>>
     <!-- General Subscription -->
     <div class="page-title">
-        <h1><?php echo $this->gethelper()->mcEscapeQuote($this->__('Newsletter Subscription')); ?></h1>
+        <h1><?php echo $this->escapeQuote($this->__('Newsletter Subscription')); ?></h1>
     </div>
     <?php echo $this->getBlockHtml('formkey'); ?>
     <div class="mailchimp-multisubscribe">
@@ -80,7 +80,7 @@ endif; ?>>
                      title="<?php echo $this->escapeHtml($generalList); ?>"
                      class="mailchimp-list-subscriber"/>
                 <label for="mailchimp-trigger">
-                    <?php echo $this->gethelper()->mcEscapeQuote($this->__('General Subscription')); ?>
+                    <?php echo $this->escapeQuote($this->__('General Subscription')); ?>
                 </label>
             </li>
         </ul>

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/checkout/subscribe.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/checkout/subscribe.phtml
@@ -66,7 +66,7 @@ $generalList = $this->getGeneralList();
 endif; ?>>
     <!-- General Subscription -->
     <div class="page-title">
-        <h1><?php echo $this->quoteEscape($this->__('Newsletter Subscription')); ?></h1>
+        <h1><?php echo $this->gethelper()->mcEscapeQuote($this->__('Newsletter Subscription')); ?></h1>
     </div>
     <?php echo $this->getBlockHtml('formkey'); ?>
     <div class="mailchimp-multisubscribe">
@@ -80,7 +80,7 @@ endif; ?>>
                      title="<?php echo $this->escapeHtml($generalList); ?>"
                      class="mailchimp-list-subscriber"/>
                 <label for="mailchimp-trigger">
-                    <?php echo $this->quoteEscape($this->__('General Subscription')); ?>
+                    <?php echo $this->gethelper()->mcEscapeQuote($this->__('General Subscription')); ?>
                 </label>
             </li>
         </ul>

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/checkout/success/groups.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/checkout/success/groups.phtml
@@ -5,13 +5,13 @@ $helper = $block->getMailChimpHelper();
 ?>
 <p>
     <?php if($helper->isInterestGroupEnabled($this->_getStoreId())): ?>
-    <?php echo $this->getMailChimpHelper()->mcEscapeQuote($block->getMessageBefore()) ?>
-<form class="form" action="<?php echo $this->getMailChimpHelper()->mcEscapeQuote($block->getFormUrl()) ?>" method="get" id="mailchimp-groups">
+    <?php echo $this->escapeQuote($block->getMessageBefore()) ?>
+<form class="form" action="<?php echo $this->escapeQuote($block->getFormUrl()) ?>" method="get" id="mailchimp-groups">
     <fieldset class="fieldset">
         <?php foreach($interest as $i): ?>
             <div class="field">
-                <label class="label" for="<?php echo $this->getMailChimpHelper()->mcEscapeQuote($i['interest']['id']) ?>">
-                    <span><?php echo $this->getMailChimpHelper()->mcEscapeQuote($i['interest']['title']) ?></span>
+                <label class="label" for="<?php echo $this->escapeQuote($i['interest']['id']) ?>">
+                    <span><?php echo $this->escapeQuote($i['interest']['title']) ?></span>
                 </label>
                 <div class="control">
                     <div class="fields">

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/checkout/success/groups.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/checkout/success/groups.phtml
@@ -5,13 +5,13 @@ $helper = $block->getMailChimpHelper();
 ?>
 <p>
     <?php if($helper->isInterestGroupEnabled($this->_getStoreId())): ?>
-    <?php echo $this->quoteEscape($block->getMessageBefore()) ?>
-<form class="form" action="<?php echo $this->quoteEscape($block->getFormUrl()) ?>" method="get" id="mailchimp-groups">
+    <?php echo $this->getMailChimpHelper()->mcEscapeQuote($block->getMessageBefore()) ?>
+<form class="form" action="<?php echo $this->getMailChimpHelper()->mcEscapeQuote($block->getFormUrl()) ?>" method="get" id="mailchimp-groups">
     <fieldset class="fieldset">
         <?php foreach($interest as $i): ?>
             <div class="field">
-                <label class="label" for="<?php echo $this->quoteEscape($i['interest']['id']) ?>">
-                    <span><?php echo $this->quoteEscape($i['interest']['title']) ?></span>
+                <label class="label" for="<?php echo $this->getMailChimpHelper()->mcEscapeQuote($i['interest']['id']) ?>">
+                    <span><?php echo $this->getMailChimpHelper()->mcEscapeQuote($i['interest']['title']) ?></span>
                 </label>
                 <div class="control">
                     <div class="fields">

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/customer/newsletter/index.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/customer/newsletter/index.phtml
@@ -6,8 +6,8 @@ $interest = $block->getInterest();
     <?php foreach($interest as $i): ?>
         <ul class="form-list">
             <li class="field no-label">
-            <label class="label" for="<?php echo $this->quoteEscape($i['interest']['id']) ?>">
-                <h4><?php echo $this->quoteEscape($i['interest']['title']) ?></h4>
+            <label class="label" for="<?php echo $this->getMailchimpHelper()->mcEscapeQuote($i['interest']['id']) ?>">
+                <h4><?php echo $this->getMailchimpHelper()->mcEscapeQuote($i['interest']['title']) ?></h4>
             </label>
             </li>
             <?php echo $this->getLayout()->createBlock(

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/customer/newsletter/index.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/customer/newsletter/index.phtml
@@ -6,8 +6,8 @@ $interest = $block->getInterest();
     <?php foreach($interest as $i): ?>
         <ul class="form-list">
             <li class="field no-label">
-            <label class="label" for="<?php echo $this->getMailchimpHelper()->mcEscapeQuote($i['interest']['id']) ?>">
-                <h4><?php echo $this->getMailchimpHelper()->mcEscapeQuote($i['interest']['title']) ?></h4>
+            <label class="label" for="<?php echo $this->escapeQuote($i['interest']['id']) ?>">
+                <h4><?php echo $this->escapeQuote($i['interest']['title']) ?></h4>
             </label>
             </li>
             <?php echo $this->getLayout()->createBlock(

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/group/type/checkboxes.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/group/type/checkboxes.phtml
@@ -14,14 +14,14 @@ $i = $this->getCurrentInterest();
                type="checkbox"
                value="<?php echo $this->escapeHtml($c['id']) ?>"
                id="<?php echo $this->escapeHtml('mailchimp_group_'.$c['id']) ?>"
-               title="<?php echo $this->quoteEscape($c['name']) ?>"
+               title="<?php echo $this->gethelper()->mcEscapeQuote($c['name']) ?>"
             <?php if ($c['checked']) {
                     echo $this->escapeHtml('checked');
             }
             ?>
         />
         <label for="<?php echo $this->escapeHtml('mailchimp_group_'.$c['id']) ?>" class="field label">
-            <?php echo $this->quoteEscape($c['name'])?>
+            <?php echo $this->gethelper()->mcEscapeQuote($c['name'])?>
         </label>
     </li>
 <?php endforeach; ?>

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/group/type/checkboxes.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/group/type/checkboxes.phtml
@@ -14,14 +14,14 @@ $i = $this->getCurrentInterest();
                type="checkbox"
                value="<?php echo $this->escapeHtml($c['id']) ?>"
                id="<?php echo $this->escapeHtml('mailchimp_group_'.$c['id']) ?>"
-               title="<?php echo $this->gethelper()->mcEscapeQuote($c['name']) ?>"
+               title="<?php echo $this->escapeQuote($c['name']) ?>"
             <?php if ($c['checked']) {
                     echo $this->escapeHtml('checked');
             }
             ?>
         />
         <label for="<?php echo $this->escapeHtml('mailchimp_group_'.$c['id']) ?>" class="field label">
-            <?php echo $this->gethelper()->mcEscapeQuote($c['name'])?>
+            <?php echo $this->escapeQuote($c['name'])?>
         </label>
     </li>
 <?php endforeach; ?>

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/group/type/dropdown.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/group/type/dropdown.phtml
@@ -12,7 +12,7 @@ $i = $this->getCurrentInterest();
             <option value="<?php echo $this->escapeHtml($c['id']) ?>" <?php if ($c['checked']) {
                 echo 'selected';
            }
-        ?>><?php echo $this->gethelper()->mcEscapeQuote($c['name']) ?></option>
+        ?>><?php echo $this->escapeQuote($c['name']) ?></option>
         <?php endforeach; ?>
     </select>
 </div>

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/group/type/dropdown.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/group/type/dropdown.phtml
@@ -12,7 +12,7 @@ $i = $this->getCurrentInterest();
             <option value="<?php echo $this->escapeHtml($c['id']) ?>" <?php if ($c['checked']) {
                 echo 'selected';
            }
-        ?>><?php echo $this->quoteEscape($c['name']) ?></option>
+        ?>><?php echo $this->gethelper()->mcEscapeQuote($c['name']) ?></option>
         <?php endforeach; ?>
     </select>
 </div>

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/group/type/radio.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/group/type/radio.phtml
@@ -10,13 +10,13 @@ $i = $this->getCurrentInterest();
                type="radio"
                value="<?php echo $this->escapeHtml($c['id']) ?>"
                id="<?php echo $this->escapeHtml('mailchimp_group_'.$c['id']) ?>"
-               title="<?php echo $this->quoteEscape($c['name']) ?>"
+               title="<?php echo $this->gethelper()->mcEscapeQuote($c['name']) ?>"
             <?php if ($c['checked']) {
                 echo $this->escapeHtml('checked');
             } ?>
         />
         <label for="<?php echo $this->escapeHtml('mailchimp_group_'.$c['id']) ?>"
-               class="field label"><?php echo $this->quoteEscape($c['name']) ?>
+               class="field label"><?php echo $this->gethelper()->mcEscapeQuote($c['name']) ?>
         </label>
     </li>
 <?php endforeach; ?>

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/group/type/radio.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/group/type/radio.phtml
@@ -10,13 +10,13 @@ $i = $this->getCurrentInterest();
                type="radio"
                value="<?php echo $this->escapeHtml($c['id']) ?>"
                id="<?php echo $this->escapeHtml('mailchimp_group_'.$c['id']) ?>"
-               title="<?php echo $this->gethelper()->mcEscapeQuote($c['name']) ?>"
+               title="<?php echo $this->escapeQuote($c['name']) ?>"
             <?php if ($c['checked']) {
                 echo $this->escapeHtml('checked');
             } ?>
         />
         <label for="<?php echo $this->escapeHtml('mailchimp_group_'.$c['id']) ?>"
-               class="field label"><?php echo $this->gethelper()->mcEscapeQuote($c['name']) ?>
+               class="field label"><?php echo $this->escapeQuote($c['name']) ?>
         </label>
     </li>
 <?php endforeach; ?>

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/popup/emailcatcher.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/popup/emailcatcher.phtml
@@ -3,11 +3,11 @@
         && Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::ENABLE_POPUP, $this->_getStoreId())): ?>
     <div id="email" style="text-align:right; display:none">
         <div id="popup-heading">
-            <h2><?php echo $this->gethelper()->mcEscapeQuote($this->_popupHeading()); ?></h2>
+            <h2><?php echo $this->escapeQuote($this->_popupHeading()); ?></h2>
         </div>
         <div id="popup-form-content">
             <div id="popup-text">
-                <p><?php echo $this->gethelper()->mcEscapeQuote($this->_popupMessage()); ?></p>
+                <p><?php echo $this->escapeQuote($this->_popupMessage()); ?></p>
             </div>
 
             <p><span id='email_error_msg' class="email_error" style="display:none">&nbsp;</span></p>
@@ -87,10 +87,10 @@
                     width: popupWidth,
 
                     zIndex: 2001,
-                    okLabel: '<?php echo $this->gethelper()->mcEscapeQuote($this->__('Confirm')) ?>',
+                    okLabel: '<?php echo $this->escapeQuote($this->__('Confirm')) ?>',
                     <?php if(!$this->_canCancel()): ?>closeOnEsc: false,
                     <?php else: ?>
-                    cancelLabel: '<?php echo $this->gethelper()->mcEscapeQuote($this->__('Close')) ?>',
+                    cancelLabel: '<?php echo $this->escapeQuote($this->__('Close')) ?>',
                     onCancel: function (win) {
                         <?php
                             if(Mage::getSingleton('core/cookie')->get('counter') !== null):
@@ -192,7 +192,7 @@
                             <?php endif ?>
                         } else {
                             $('email_error_msg').innerHTML = '<?php
-                                    echo $this->gethelper()->mcEscapeQuote(
+                                    echo $this->escapeQuote(
                                         $this->__('Not a valid e-mail address')
                                     );
                                 ?>';

--- a/app/design/frontend/base/default/template/ebizmarts/mailchimp/popup/emailcatcher.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/mailchimp/popup/emailcatcher.phtml
@@ -3,11 +3,11 @@
         && Mage::getStoreConfig(Ebizmarts_MailChimp_Model_Config::ENABLE_POPUP, $this->_getStoreId())): ?>
     <div id="email" style="text-align:right; display:none">
         <div id="popup-heading">
-            <h2><?php echo $this->quoteEscape($this->_popupHeading()); ?></h2>
+            <h2><?php echo $this->gethelper()->mcEscapeQuote($this->_popupHeading()); ?></h2>
         </div>
         <div id="popup-form-content">
             <div id="popup-text">
-                <p><?php echo $this->quoteEscape($this->_popupMessage()); ?></p>
+                <p><?php echo $this->gethelper()->mcEscapeQuote($this->_popupMessage()); ?></p>
             </div>
 
             <p><span id='email_error_msg' class="email_error" style="display:none">&nbsp;</span></p>
@@ -87,10 +87,10 @@
                     width: popupWidth,
 
                     zIndex: 2001,
-                    okLabel: '<?php echo $this->quoteEscape($this->__('Confirm')) ?>',
+                    okLabel: '<?php echo $this->gethelper()->mcEscapeQuote($this->__('Confirm')) ?>',
                     <?php if(!$this->_canCancel()): ?>closeOnEsc: false,
                     <?php else: ?>
-                    cancelLabel: '<?php echo $this->quoteEscape($this->__('Close')) ?>',
+                    cancelLabel: '<?php echo $this->gethelper()->mcEscapeQuote($this->__('Close')) ?>',
                     onCancel: function (win) {
                         <?php
                             if(Mage::getSingleton('core/cookie')->get('counter') !== null):
@@ -192,7 +192,7 @@
                             <?php endif ?>
                         } else {
                             $('email_error_msg').innerHTML = '<?php
-                                    echo $this->quoteEscape(
+                                    echo $this->gethelper()->mcEscapeQuote(
                                         $this->__('Not a valid e-mail address')
                                     );
                                 ?>';

--- a/dev/tests/mailchimp/autoload.php
+++ b/dev/tests/mailchimp/autoload.php
@@ -2,7 +2,7 @@
 
 $magentoRoot = getenv('MAGENTO_ROOT');
 if (empty($magentoRoot)) {
-    $magentoRoot = realpath(dirname(dirname(dirname(dirname(dirname(__DIR__))))));
+    $magentoRoot = realpath(dirname(dirname(dirname(__DIR__))));
 }
 
 define('MAGENTO_ROOT', $magentoRoot);

--- a/dev/tests/mailchimp/autoload.php
+++ b/dev/tests/mailchimp/autoload.php
@@ -2,7 +2,7 @@
 
 $magentoRoot = getenv('MAGENTO_ROOT');
 if (empty($magentoRoot)) {
-    $magentoRoot = realpath(dirname(dirname(dirname(__DIR__))));
+    $magentoRoot = realpath(dirname(dirname(dirname(dirname(dirname(__DIR__))))));
 }
 
 define('MAGENTO_ROOT', $magentoRoot);


### PR DESCRIPTION
Ref. #1114 

Due the M1.7 error with EscapeQuote method because it doesn't exists until version 1.8, we created a function in our helper to call the same PHP version that escapeQuote calls in Magento +1.8.