### PR TITLE
Fix getAddressData in MailchimpTags build

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Subscribers/MailchimpTags.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Subscribers/MailchimpTags.php
@@ -459,43 +459,43 @@ class Ebizmarts_MailChimp_Model_Api_Subscribers_MailchimpTags
     }
 
     /**
-     * @param $address
+     * @param $customerAddress
      * @return array | returns an array with the address data of the customer.
      */
-    protected function getAddressData($address)
+    protected function getAddressData($customerAddress)
     {
-        $lastOrder = $this->getLastOrderByEmail();
-        $addressData = $this->getAddressFromLastOrder($lastOrder);
-        if (!empty($addressData)) {
-            if ($address) {
-                $street = $address->getStreet();
-                if (count($street) > 1) {
-                    $addressData["addr1"] = $street[0];
-                    $addressData["addr2"] = $street[1];
-                } else {
-                    if (!empty($street[0])) {
-                        $addressData["addr1"] = $street[0];
-                    }
-                }
+        if (!$customerAddress || !$customerAddress->getId()) {
+            return [];
+        }
 
-                if ($address->getCity()) {
-                    $addressData["city"] = $address->getCity();
-                }
+        $addressData = [];
 
-                if ($address->getRegion()) {
-                    $addressData["state"] = $address->getRegion();
-                }
-
-                if ($address->getPostcode()) {
-                    $addressData["zip"] = $address->getPostcode();
-                }
-
-                if ($address->getCountry()) {
-                    $addressData["country"] = Mage::getModel('directory/country')
-                        ->loadByCode($address->getCountry())
-                        ->getName();
-                }
+        $street = $customerAddress->getStreet();
+        if (count($street) > 1) {
+            $addressData["addr1"] = $street[0];
+            $addressData["addr2"] = $street[1];
+        } else {
+            if (!empty($street[0])) {
+                $addressData["addr1"] = $street[0];
             }
+        }
+
+        if ($customerAddress->getCity()) {
+            $addressData["city"] = $customerAddress->getCity();
+        }
+
+        if ($customerAddress->getRegion()) {
+            $addressData["state"] = $customerAddress->getRegion();
+        }
+
+        if ($customerAddress->getPostcode()) {
+            $addressData["zip"] = $customerAddress->getPostcode();
+        }
+
+        if ($customerAddress->getCountry()) {
+            $addressData["country"] = Mage::getModel('directory/country')
+                ->loadByCode($customerAddress->getCountry())
+                ->getName();
         }
 
         return $addressData;


### PR DESCRIPTION
The `\Ebizmarts_MailChimp_Model_Api_Subscribers_MailchimpTags::getAddressData` method appears to be wrong and this PR aims to fix it.

Prior to this PR:
* If the customer has a default billing and shipping address but has not any order, its BILLING and SHIPPING tags are not exported, which is wrong.
* If the customer has at least one order its BILLING and SHIPPING relevant properties are built with the customer's default address anyway, which has no sense at all.
* In some situations the `getAddressData` method returns an instance of `Mage_Sales_Model_Address` instead of an array. This cause an empty JSON object passed to Mailchimp API which leads to the "_Data did not match any of the schemas described in anyOf_" error.

After this PR, if the customer has a default billing/shipping address it will be always exported as the BILLING/SHIPPING tags regardless the presence of any order.