### PR TITLE
Promo Rule and Promo Code related are properly deleted both in Magento and Mailchimp

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/Batches.php
@@ -525,7 +525,7 @@ class Ebizmarts_MailChimp_Model_Api_Batches
         $resource = $helper->getCoreResource();
         $connection = $resource->getConnection('core_write');
         $tableName = $resource->getTableName('mailchimp/ecommercesyncdata');
-        $where = array("batch_id IS NULL AND mailchimp_sync_modified != 1");
+        $where = array("batch_id IS NULL AND mailchimp_sync_modified != 1 AND mailchimp_sync_deleted != 1");
         $connection->delete($tableName, $where);
     }
 
@@ -709,7 +709,7 @@ class Ebizmarts_MailChimp_Model_Api_Batches
             if ($fileHelper->isDir($baseDir.DS.'var'.DS.'mailchimp') == false)
             {
                 $fileHelper->mkDir($baseDir.DS.'var'.DS.'mailchimp');
-            } 
+            }
             if ($api) {
                 // check the status of the job
                 $response = $api->batchOperation->status($batchId);

--- a/app/code/community/Ebizmarts/MailChimp/Model/Api/PromoCodes.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Api/PromoCodes.php
@@ -412,6 +412,7 @@ class Ebizmarts_MailChimp_Model_Api_PromoCodes extends Ebizmarts_MailChimp_Model
 
         foreach ($promoCodes as $promoCode) {
             $mailchimpStoreId = $promoCode->getMailchimpStoreId();
+            $this->setMailchimpStoreId($mailchimpStoreId);
             $this->addDeletedRelatedId($codeId, $promoRuleId);
         }
     }

--- a/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/Observer.php
@@ -1025,10 +1025,15 @@ class Ebizmarts_MailChimp_Model_Observer
 
     public function salesruleDeleteAfter(Varien_Event_Observer $observer)
     {
-        $promoRulesApi = $this->makeApiPromoRule();
         $rule = $observer->getEvent()->getRule();
         $ruleId = $rule->getRuleId();
+        $couponId = $rule->getPrimaryCoupon()->getData() ['coupon_id'];
+
+        $promoRulesApi = $this->makeApiPromoRule();
         $promoRulesApi->markAsDeleted($ruleId);
+
+        $promoCodesApi = $this->makeApiPromoCode();
+        $promoCodesApi->markAsDeleted($couponId, $ruleId);
 
         return $observer;
     }


### PR DESCRIPTION
Promo Rule deletion from Shopping Cart Price Rules now get reflected in Mailchimp. And mailchimp_ecommerce_sync_data table gets properly updated.

closes #1253