### PR TITLE
Resolve PHP 7.4 incompatibility in the ClearEcommerce model

### DIFF
--- a/app/code/community/Ebizmarts/MailChimp/Model/ClearEcommerce.php
+++ b/app/code/community/Ebizmarts/MailChimp/Model/ClearEcommerce.php
@@ -281,7 +281,7 @@ class Ebizmarts_MailChimp_Model_ClearEcommerce
     public function deleteEcommerceRows($ids, $type)
     {
         $ids = array_filter($ids);
-        $ids = implode($ids, ', ');
+        $ids = implode(',' , $ids);
         $where = array(
             "related_id IN ($ids)",
             "type = '$type'"


### PR DESCRIPTION
This PR resolves a PHP 7.4 incompatibility in the `Ebizmarts_MailChimp_Model_ClearEcommerce` class.

The following was reported by the [PHP Compatibility Coding Standard for PHP_CodeSniffer](https://github.com/PHPCompatibility/PHPCompatibility):

    FILE: /path/to/magento/app/code/community/Ebizmarts/MailChimp/Model/ClearEcommerce.php
    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
    FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     284 | WARNING | Passing the $glue and $pieces parameters in reverse order to implode has been deprecated since PHP 7.4; $glue should be the first parameter and $pieces the second
    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------